### PR TITLE
Camera report

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Constants contains values that will never be changed. This prevents "magic numbe
 
 | Index              | Data                    | Min (if applicable) | Max (if applicable) |
 | ------------------ | ----------------------- | ------------------- | ------------------- |
-| 0                  | FD (253 in decimal)     | N/A                 | N/A                 |
+| 0                  | 253 (normel report flag)| N/A                 | N/A                 |
 | 1                  | photoresistor covered   |                     |                     |
 | 2                  | button pressed          |                     |                     |
 | 3                  | mission mode            |                     |                     |
@@ -162,8 +162,8 @@ Constants contains values that will never be changed. This prevents "magic numbe
 | 35                 | take photo              |                     |                     |
 | 36                 | camera powered          |                     |                     |
 | ...                | opcodes of received commands|                     |                     |
-| report.size() - 2  | FE (254 in decimal)     |                     |                     |
-| report.size() - 2  | FF (255 in decimal)     |                     |                     |
+| report.size() - 2  | 254 (end flag 1)        |                     |                     |
+| report.size() - 2  | 255 (end flag 2)        |                     |                     |
 
 **<center> Tests</center>**
 

--- a/README.md
+++ b/README.md
@@ -122,45 +122,48 @@ Constants contains values that will never be changed. This prevents "magic numbe
 **<center> Normal Report</center>**
 *Format for downlinked data.*
 
-| Index | Data                    | Min (if applicable) | Max (if applicable) |
-| ----- | ----------------------- | ------------------- | ------------------- |
-| 0     | 21 (normal report flag) | N/A                 | N/A                 |
-| 1     | photoresistor covered   |                     |                     |
-| 2     | button pressed          |                     |                     |
-| 3     | mission mode            |                     |                     |
-| 4     | burn wire fire          |                     |                     |
-| 5     | burn wire arm           |                     |                     |
-| 6     | burn wire time          | 0                   | 60000               |
-| 7     | burn wire armed time    | 0                   | 86400000            |
-| 8     | burn wire mode          |                     |                     |
-| 9     | burn wire attempts      |                     | 10                  |
-| 10    | downlink period         | 1000                | 172800000           |
-| 11    | waiting message         |                     |                     |
-| 12    | waiting command         |                     |                     |
-| 13    | mag\_x                  | 0.0                 | 0.0                 |
-| 14    | mag\_y                  | 0.0                 | 0.0                 |
-| 15    | mag\_z                  | 0.0                 | 0.0                 |
-| 16    | gyro\_x                 | 0.0                 | 0.0                 |
-| 17    | gryo\_y                 | 0.0                 | 0.0                 |
-| 18    | gyro\_z                 | 0.0                 | 0.0                 |
-| 19    | temperature             |                     | 200                 |
-| 20    | temperature mode        |                     |                     |
-| 21    | solar current           |                     | 500                 |
-| 22    | in sun                  |                     |                     |
-| 23    | acs mode                |                     |                     |
-| 24    | voltage                 | 3                   | 5                   |
-| 25    | fault mode              |                     |                     |
-| 26    | mag\_x fault check      |                     |                     |
-| 27    | mag\_y fault check      |                     |                     |
-| 28    | mag\_z fault check      |                     |                     |
-| 29    | gyro\_x fault check     |                     |                     |
-| 30    | gyro\_y fault check     |                     |                     |
-| 31    | gyro\_z fault check     |                     |                     |
-| 32    | temp fault check        |                     |                     |
-| 33    | voltage fault check     |                     |                     |
-| 34    | solar fault check       |                     |                     |
-| 35    | take photo              |                     |                     |
-| 36    | camera powered          |                     |                     |
+| Index              | Data                    | Min (if applicable) | Max (if applicable) |
+| ------------------ | ----------------------- | ------------------- | ------------------- |
+| 0                  | FD (253 in decimal)     | N/A                 | N/A                 |
+| 1                  | photoresistor covered   |                     |                     |
+| 2                  | button pressed          |                     |                     |
+| 3                  | mission mode            |                     |                     |
+| 4                  | burn wire fire          |                     |                     |
+| 5                  | burn wire arm           |                     |                     |
+| 6                  | burn wire time          | 0                   | 60000               |
+| 7                  | burn wire armed time    | 0                   | 86400000            |
+| 8                  | burn wire mode          |                     |                     |
+| 9                  | burn wire attempts      |                     | 10                  |
+| 10                 | downlink period         | 1000                | 172800000           |
+| 11                 | waiting message         |                     |                     |
+| 12                 | waiting command         |                     |                     |
+| 13                 | mag\_x                  | 0.0                 | 0.0                 |
+| 14                 | mag\_y                  | 0.0                 | 0.0                 |
+| 15                 | mag\_z                  | 0.0                 | 0.0                 |
+| 16                 | gyro\_x                 | 0.0                 | 0.0                 |
+| 17                 | gryo\_y                 | 0.0                 | 0.0                 |
+| 18                 | gyro\_z                 | 0.0                 | 0.0                 |
+| 19                 | temperature             |                     | 200                 |
+| 20                 | temperature mode        |                     |                     |
+| 21                 | solar current           |                     | 500                 |
+| 22                 | in sun                  |                     |                     |
+| 23                 | acs mode                |                     |                     |
+| 24                 | voltage                 | 3                   | 5                   |
+| 25                 | fault mode              |                     |                     |
+| 26                 | mag\_x fault check      |                     |                     |
+| 27                 | mag\_y fault check      |                     |                     |
+| 28                 | mag\_z fault check      |                     |                     |
+| 29                 | gyro\_x fault check     |                     |                     |
+| 30                 | gyro\_y fault check     |                     |                     |
+| 31                 | gyro\_z fault check     |                     |                     |
+| 32                 | temp fault check        |                     |                     |
+| 33                 | voltage fault check     |                     |                     |
+| 34                 | solar fault check       |                     |                     |
+| 35                 | take photo              |                     |                     |
+| 36                 | camera powered          |                     |                     |
+| ...                | opcodes of received commands|                     |                     |
+| report.size() - 2  | FE (254 in decimal)     |                     |                     |
+| report.size() - 2  | FF (255 in decimal)     |                     |                     |
 
 **<center> Tests</center>**
 

--- a/src/Control Tasks/RockblockControlTask.cpp
+++ b/src/Control Tasks/RockblockControlTask.cpp
@@ -220,8 +220,9 @@ void RockblockControlTask::dispatch_send_message()
 #ifdef VERBOSE
     Serial.print("SENT: ");
 #endif
-    for (size_t i = 0; i < constants::rockblock::packet_size; ++i) {
-        if (sfr::rockblock::downlink_camera == false) {
+
+    if (sfr::rockblock::downlink_camera == false) {
+        for (size_t i = 0; i < sfr::rockblock::report.size(); ++i) {
 #ifdef VERBOSE
             if (sfr::rockblock::report[i] < 16) {
                 Serial.print(0);
@@ -230,7 +231,9 @@ void RockblockControlTask::dispatch_send_message()
 #endif
             sfr::rockblock::serial.write(sfr::rockblock::report[i]);
             checksum += (uint16_t)sfr::rockblock::report[i];
-        } else {
+        }
+    } else {
+        for (size_t i = 0; i < sfr::rockblock::camera_report.size(); ++i) {
 #ifdef VERBOSE
             if (sfr::rockblock::camera_report[i] < 16) {
                 Serial.print(0);
@@ -241,6 +244,7 @@ void RockblockControlTask::dispatch_send_message()
             checksum += (uint16_t)sfr::rockblock::camera_report[i];
         }
     }
+
 #ifdef VERBOSE
     Serial.println();
     Serial.print("SENT: ");

--- a/src/Monitors/CameraReportMonitor.cpp
+++ b/src/Monitors/CameraReportMonitor.cpp
@@ -97,8 +97,6 @@ void CameraReportMonitor::create_camera_report(int fragment_number, uint8_t seri
         sfr::rockblock::camera_report.push_back(parsedbuffer[z]);
         z = z + 1;
     }
-    sfr::rockblock::camera_report.push_back(constants::rockblock::end_of_camera_downlink_flag1);
-    sfr::rockblock::camera_report.push_back(constants::rockblock::end_of_camera_downlink_flag2);
     sfr::camera::report_ready = true;
     sfr::camera::report_downlinked = false;
 }

--- a/src/Monitors/CameraReportMonitor.cpp
+++ b/src/Monitors/CameraReportMonitor.cpp
@@ -74,9 +74,9 @@ void CameraReportMonitor::create_camera_report(int fragment_number, uint8_t seri
     }
     imgFile.close();
 
-    sfr::rockblock::camera_report[0] = 42;
+    sfr::rockblock::camera_report.push_back(42);
     // get each byte of serial number and add to camera report
-    sfr::rockblock::camera_report[1] = serial_number;
+    sfr::rockblock::camera_report.push_back(serial_number);
 
     // get each byte of fragment number
     std::vector<unsigned char> fragment(constants::camera::bytes_allocated_fragment);
@@ -86,19 +86,15 @@ void CameraReportMonitor::create_camera_report(int fragment_number, uint8_t seri
 
     // add fragment number to camera report
     size_t i = 0;
-    int a = constants::camera::bytes_allocated_serial_opcode;
     while (i < constants::camera::bytes_allocated_fragment) {
-        sfr::rockblock::camera_report[a] = fragment[i];
-        a = a + 1;
+        sfr::rockblock::camera_report.push_back(fragment[i]);
         i = i + 1;
     }
 
     // add actual image content to camera report
     int z = 0;
-    int y = constants::camera::bytes_allocated_serial_opcode + constants::camera::bytes_allocated_fragment;
     while (z < constants::camera::content_length) {
-        sfr::rockblock::camera_report[y] = parsedbuffer[z];
-        y = y + 1;
+        sfr::rockblock::camera_report.push_back(parsedbuffer[z]);
         z = z + 1;
     }
     sfr::camera::report_ready = true;

--- a/src/Monitors/CameraReportMonitor.cpp
+++ b/src/Monitors/CameraReportMonitor.cpp
@@ -97,6 +97,8 @@ void CameraReportMonitor::create_camera_report(int fragment_number, uint8_t seri
         sfr::rockblock::camera_report.push_back(parsedbuffer[z]);
         z = z + 1;
     }
+    sfr::rockblock::camera_report.push_back(constants::rockblock::end_of_camera_downlink_flag1);
+    sfr::rockblock::camera_report.push_back(constants::rockblock::end_of_camera_downlink_flag2);
     sfr::camera::report_ready = true;
     sfr::camera::report_downlinked = false;
 }

--- a/src/Monitors/NormalReportMonitor.cpp
+++ b/src/Monitors/NormalReportMonitor.cpp
@@ -69,5 +69,6 @@ void NormalReportMonitor::execute()
     } // Writes opcodes to normal report; two indices constitute one opcode since each opcode is 2-byte
     std::queue<uint8_t> empty;
     std::swap(commands_received, empty); // Clear the queue after each normal report is generated
-    sfr::rockblock::report.push_back(constants::rockblock::end_of_normal_downlink_flag);
+    sfr::rockblock::report.push_back(constants::rockblock::end_of_normal_downlink_flag1);
+    sfr::rockblock::report.push_back(constants::rockblock::end_of_normal_downlink_flag2);
 }

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -60,8 +60,12 @@ namespace constants {
         constexpr size_t max_conseq_read = 3;
 
         constexpr int num_initial_downlinks = 2;
-        constexpr uint8_t start_of_normal_downlink_flag = 254;
-        constexpr uint8_t end_of_normal_downlink_flag = 255;
+        constexpr uint8_t start_of_normal_downlink_flag = 253;
+        constexpr uint8_t end_of_normal_downlink_flag1 = 254;
+        constexpr uint8_t end_of_normal_downlink_flag2 = 255;
+
+        constexpr uint8_t end_of_camera_downlink_flag1 = 251;
+        constexpr uint8_t end_of_camera_downlink_flag2 = 252;
 
         constexpr uint8_t mission_mode[opcode_len] = {0x00, 0x00};
         constexpr uint8_t burnwire_arm[opcode_len] = {0x01, 0x00};

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -64,9 +64,6 @@ namespace constants {
         constexpr uint8_t end_of_normal_downlink_flag1 = 254;
         constexpr uint8_t end_of_normal_downlink_flag2 = 255;
 
-        constexpr uint8_t end_of_camera_downlink_flag1 = 251;
-        constexpr uint8_t end_of_camera_downlink_flag2 = 252;
-
         constexpr uint8_t mission_mode[opcode_len] = {0x00, 0x00};
         constexpr uint8_t burnwire_arm[opcode_len] = {0x01, 0x00};
         constexpr uint8_t burnwire_fire[opcode_len] = {0x02, 0x00};

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -60,8 +60,8 @@ namespace constants {
         constexpr size_t max_conseq_read = 3;
 
         constexpr int num_initial_downlinks = 2;
-        constexpr uint8_t start_of_normal_downlink_flag = 21;
-        constexpr uint8_t end_of_normal_downlink_flag = 22;
+        constexpr uint8_t start_of_normal_downlink_flag = 254;
+        constexpr uint8_t end_of_normal_downlink_flag = 255;
 
         constexpr uint8_t mission_mode[opcode_len] = {0x00, 0x00};
         constexpr uint8_t burnwire_arm[opcode_len] = {0x01, 0x00};
@@ -469,7 +469,7 @@ namespace constants {
 
         // number being added is the time length of the previous function
         // battery monitor takes max 60 us, so button monitor will start 60us after
-        static constexpr unsigned int acs_monitor_offset = 0;                          // time starts at 0
+        static constexpr unsigned int acs_monitor_offset = 0;     // time starts at 0
         static constexpr unsigned int battery_monitor_offset = 0; // to be determined
         static constexpr unsigned int button_monitor_offset = 0;
         static constexpr unsigned int camera_report_monitor_offset = 0;
@@ -482,7 +482,7 @@ namespace constants {
         static constexpr unsigned int temperature_monitor_offset = 0;
 
         static constexpr unsigned int acs_control_task_offset = 0;
-        static constexpr unsigned int burnwire_control_task_offset = 0; 
+        static constexpr unsigned int burnwire_control_task_offset = 0;
         static constexpr unsigned int camera_control_task_offset = 0;
         static constexpr unsigned int rockblock_control_task_offset = 0;
         static constexpr unsigned int temperature_control_task_offset = 0;

--- a/src/sfr.cpp
+++ b/src/sfr.cpp
@@ -92,7 +92,8 @@ namespace sfr {
         bool waiting_message = false;
         char buffer[constants::rockblock::buffer_size] = {0};
         std::deque<uint8_t> report;
-        uint8_t camera_report[constants::rockblock::packet_size] = {0};
+        std::deque<uint8_t> camera_report;
+        // uint8_t camera_report[constants::rockblock::packet_size] = {0};
         int commas[constants::rockblock::num_commas] = {0};
         uint8_t opcode[2] = {0};
         uint8_t arg_1[4] = {0};

--- a/src/sfr.hpp
+++ b/src/sfr.hpp
@@ -98,7 +98,8 @@ namespace sfr {
         extern bool waiting_message;
         extern char buffer[constants::rockblock::buffer_size];
         extern std::deque<uint8_t> report;
-        extern uint8_t camera_report[constants::rockblock::packet_size];
+        extern std::deque<uint8_t> camera_report;
+        // extern uint8_t camera_report[constants::rockblock::packet_size];
         extern int commas[constants::rockblock::num_commas];
         extern uint8_t opcode[2];
         extern uint8_t arg_1[4];

--- a/test/test_report_acknowledge/test_report_acknowledge.cpp
+++ b/test/test_report_acknowledge/test_report_acknowledge.cpp
@@ -8,7 +8,7 @@ void test_normal_report_without_commands()
 {
     NormalReportMonitor normal_report_monitor(0);
     normal_report_monitor.execute();
-    TEST_ASSERT_EQUAL(37, sfr::rockblock::report.size());
+    TEST_ASSERT_EQUAL(38, sfr::rockblock::report.size());
 }
 
 void test_normal_report_with_one_command()
@@ -22,7 +22,7 @@ void test_normal_report_with_one_command()
     normal_report_monitor.execute();
     TEST_ASSERT_EQUAL(constants::rockblock::mission_mode[0], sfr::rockblock::report[36]);
     TEST_ASSERT_EQUAL(constants::rockblock::mission_mode[1], sfr::rockblock::report[37]);
-    TEST_ASSERT_EQUAL(39, sfr::rockblock::report.size());
+    TEST_ASSERT_EQUAL(40, sfr::rockblock::report.size());
 }
 
 void test_normal_report_with_multiple_commands()
@@ -42,7 +42,7 @@ void test_normal_report_with_multiple_commands()
     TEST_ASSERT_EQUAL(constants::rockblock::mission_mode[1], sfr::rockblock::report[37]);
     TEST_ASSERT_EQUAL(constants::rockblock::burnwire_arm[0], sfr::rockblock::report[38]);
     TEST_ASSERT_EQUAL(constants::rockblock::burnwire_arm[1], sfr::rockblock::report[39]);
-    TEST_ASSERT_EQUAL(41, sfr::rockblock::report.size());
+    TEST_ASSERT_EQUAL(42, sfr::rockblock::report.size());
 }
 
 void test_normal_report_with_more_than_15_commands()
@@ -64,8 +64,9 @@ void test_normal_report_with_more_than_15_commands()
         TEST_ASSERT_EQUAL(constants::rockblock::burnwire_arm[1], sfr::rockblock::report[36 + (i * 2) + 1]);
         ++i;
     }
-    TEST_ASSERT_EQUAL(constants::rockblock::end_of_normal_downlink_flag, sfr::rockblock::report[66]);
-    TEST_ASSERT_EQUAL(67, sfr::rockblock::report.size());
+    TEST_ASSERT_EQUAL(constants::rockblock::end_of_normal_downlink_flag1, sfr::rockblock::report[66]);
+    TEST_ASSERT_EQUAL(constants::rockblock::end_of_normal_downlink_flag2, sfr::rockblock::report[67]);
+    TEST_ASSERT_EQUAL(68, sfr::rockblock::report.size());
 }
 
 int test_normal_report_acknowledge()


### PR DESCRIPTION
- Change normal report structure to include two end-of-downlink flags
- Restructure the camera report with a length-adjustable deque
- Test with RockBlock Simulator
- Change the actual downlink packet size in RockblockControlTask
- Modify unit tests for the above changes