### PR TITLE
[IMUMonitor] Implement check for repeated buffer values in `IMUMonitor`

### DIFF
--- a/src/Monitors/IMUMonitor.cpp
+++ b/src/Monitors/IMUMonitor.cpp
@@ -42,6 +42,22 @@ void IMUMonitor::execute()
     }
 }
 
+bool check_repeated_values(std::deque<float> buffer)
+{
+    if (buffer.empty() || buffer.size() == 1) {
+        return false;
+    }
+
+    int first_val = buffer[0];
+    for (float val : buffer) {
+        if (first_val != val) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 void IMUMonitor::capture_imu_values()
 {
     sensors_event_t accel, mag, gyro, temp;
@@ -111,24 +127,55 @@ void IMUMonitor::capture_imu_values()
         sfr::imu::gyro_z_buffer.pop_back();
     }
 
-    // Calculate sums
+    // Check for repeated/invalid readings, calculate sums and average
 
-    float mag_x_sum = std::accumulate(sfr::imu::mag_x_buffer.begin(), sfr::imu::mag_x_buffer.end(), 0.0);
-    float mag_y_sum = std::accumulate(sfr::imu::mag_y_buffer.begin(), sfr::imu::mag_y_buffer.end(), 0.0);
-    float mag_z_sum = std::accumulate(sfr::imu::mag_z_buffer.begin(), sfr::imu::mag_z_buffer.end(), 0.0);
-    float gyro_x_sum = std::accumulate(sfr::imu::gyro_x_buffer.begin(), sfr::imu::gyro_x_buffer.end(), 0.0);
-    float gyro_y_sum = std::accumulate(sfr::imu::gyro_y_buffer.begin(), sfr::imu::gyro_y_buffer.end(), 0.0);
-    float gyro_z_sum = std::accumulate(sfr::imu::gyro_z_buffer.begin(), sfr::imu::gyro_z_buffer.end(), 0.0);
+    if (check_repeated_values(sfr::imu::mag_x_buffer)) {
+        sfr::imu::mag_x_average->set_invalid();
+    } else {
+        sfr::imu::mag_x_average->set_valid();
+        float mag_x_sum = std::accumulate(sfr::imu::mag_x_buffer.begin(), sfr::imu::mag_x_buffer.end(), 0.0);
+        sfr::imu::mag_x_average->set_value(mag_x_sum / sfr::imu::mag_x_buffer.size());
+    }
 
-    // Calculate averages
+    if (check_repeated_values(sfr::imu::mag_y_buffer)) {
+        sfr::imu::mag_y_average->set_invalid();
+    } else {
+        sfr::imu::mag_y_average->set_valid();
+        float mag_y_sum = std::accumulate(sfr::imu::mag_y_buffer.begin(), sfr::imu::mag_y_buffer.end(), 0.0);
+        sfr::imu::mag_y_average->set_value(mag_y_sum / sfr::imu::mag_y_buffer.size());
+    }
 
-    sfr::imu::mag_x_average->set_value(mag_x_sum / sfr::imu::mag_x_buffer.size());
-    sfr::imu::mag_y_average->set_value(mag_y_sum / sfr::imu::mag_y_buffer.size());
-    sfr::imu::mag_z_average->set_value(mag_z_sum / sfr::imu::mag_z_buffer.size());
+    if (check_repeated_values(sfr::imu::mag_z_buffer)) {
+        sfr::imu::mag_z_average->set_invalid();
+    } else {
+        sfr::imu::mag_z_average->set_valid();
+        float mag_z_sum = std::accumulate(sfr::imu::mag_z_buffer.begin(), sfr::imu::mag_z_buffer.end(), 0.0);
+        sfr::imu::mag_z_average->set_value(mag_z_sum / sfr::imu::mag_z_buffer.size());
+    }
 
-    sfr::imu::gyro_x_average->set_value(gyro_x_sum / sfr::imu::gyro_x_buffer.size());
-    sfr::imu::gyro_y_average->set_value(gyro_y_sum / sfr::imu::gyro_y_buffer.size());
-    sfr::imu::gyro_z_average->set_value(gyro_z_sum / sfr::imu::gyro_z_buffer.size());
+    if (check_repeated_values(sfr::imu::gyro_x_buffer)) {
+        sfr::imu::gyro_x_average->set_invalid();
+    } else {
+        sfr::imu::gyro_x_average->set_valid();
+        float gyro_x_sum = std::accumulate(sfr::imu::gyro_x_buffer.begin(), sfr::imu::gyro_x_buffer.end(), 0.0);
+        sfr::imu::gyro_x_average->set_value(gyro_x_sum / sfr::imu::gyro_x_buffer.size());
+    }
+
+    if (check_repeated_values(sfr::imu::gyro_y_buffer)) {
+        sfr::imu::gyro_y_average->set_invalid();
+    } else {
+        sfr::imu::gyro_y_average->set_valid();
+        float gyro_y_sum = std::accumulate(sfr::imu::gyro_y_buffer.begin(), sfr::imu::gyro_y_buffer.end(), 0.0);
+        sfr::imu::gyro_y_average->set_value(gyro_y_sum / sfr::imu::gyro_y_buffer.size());
+    }
+
+    if (check_repeated_values(sfr::imu::gyro_z_buffer)) {
+        sfr::imu::gyro_z_average->set_invalid();
+    } else {
+        sfr::imu::gyro_z_average->set_valid();
+        float gyro_z_sum = std::accumulate(sfr::imu::gyro_z_buffer.begin(), sfr::imu::gyro_z_buffer.end(), 0.0);
+        sfr::imu::gyro_z_average->set_value(gyro_z_sum / sfr::imu::gyro_z_buffer.size());
+    }
 }
 
 void IMUMonitor::transition_to_normal()


### PR DESCRIPTION
- Add check in `IMUMonitor` that marks sensor readings as invalid if all the buffer values are the same.
- Addresses `FS-117` (https://ssdsalphacubesat.atlassian.net/jira/software/c/projects/FS/boards/1?modal=detail&selectedIssue=FS-117).