### PR TITLE
add photoresistor value to normal report

### DIFF
--- a/src/Monitors/NormalReportMonitor.cpp
+++ b/src/Monitors/NormalReportMonitor.cpp
@@ -14,6 +14,8 @@ void NormalReportMonitor::execute()
     uint8_t gyro_y = map(sfr::imu::gyro_y_average->get_value(), constants::imu::min_gyro_y, constants::imu::max_gyro_y, 0, 255);
     uint8_t gyro_z = map(sfr::imu::gyro_z_average->get_value(), constants::imu::min_gyro_z, constants::imu::max_gyro_z, 0, 255);
 
+    uint8_t light_val = map(sfr::photoresistor::val, constants::photoresistor::min_val, constants::photoresistor::max_val, 0, 255);
+
     uint8_t temp_c = map(sfr::temperature::temp_c_average->get_value(), constants::temperature::min_temp_c, constants::temperature::max_temp_c, 0, 255);
 
     // TODO: finalize min/max
@@ -43,6 +45,7 @@ void NormalReportMonitor::execute()
     sfr::rockblock::normal_report.push_back(gyro_x);
     sfr::rockblock::normal_report.push_back(gyro_y);
     sfr::rockblock::normal_report.push_back(gyro_z);
+    sfr::rockblock::normal_report.push_back(light_val);
     sfr::rockblock::normal_report.push_back(temp_c);
     // removed temperature mode type
     sfr::rockblock::normal_report.push_back(solar_current);
@@ -56,6 +59,7 @@ void NormalReportMonitor::execute()
     sfr::rockblock::normal_report.push_back(sfr::imu::gyro_x_average->is_valid());
     sfr::rockblock::normal_report.push_back(sfr::imu::gyro_y_average->is_valid());
     sfr::rockblock::normal_report.push_back(sfr::imu::gyro_z_average->is_valid());
+    sfr::rockblock::normal_report.push_back(sfr::photoresistor::covered);
     sfr::rockblock::normal_report.push_back(sfr::temperature::temp_c_average->is_valid());
     sfr::rockblock::normal_report.push_back(sfr::battery::voltage_average->is_valid());
     sfr::rockblock::normal_report.push_back(sfr::current::solar_current_average->is_valid());

--- a/src/Monitors/PhotoresistorMonitor.cpp
+++ b/src/Monitors/PhotoresistorMonitor.cpp
@@ -4,13 +4,13 @@ PhotoresistorMonitor::PhotoresistorMonitor(unsigned int offset) : TimedControlTa
 
 void PhotoresistorMonitor::execute()
 {
-    int val = analogRead(constants::photoresistor::pin);
+    sfr::photoresistor::val = analogRead(constants::photoresistor::pin);
 #ifdef VERBOSE
     Serial.print("Photoresistor: ");
-    Serial.print(val);
+    Serial.print(sfr::photoresistor::val);
     Serial.println(" (0-1023 scale)");
 #endif
-    if (val > constants::photoresistor::light_val) {
+    if (sfr::photoresistor::val > constants::photoresistor::light_val) {
         sfr::photoresistor::covered = false;
     } else {
         sfr::photoresistor::covered = true;

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -22,6 +22,8 @@ namespace constants {
     namespace photoresistor {
         constexpr int pin = 38;
         constexpr int light_val = 150;
+        constexpr int min_val = 0;
+        constexpr int max_val = 1023;
     } // namespace photoresistor
     namespace burnwire {
         constexpr int first_pin = 14;

--- a/src/sfr.cpp
+++ b/src/sfr.cpp
@@ -39,6 +39,7 @@ namespace sfr {
             {constants::button::button_pin, LOW}};
     } // namespace pins
     namespace photoresistor {
+        int val = 0;
         bool covered = true;
     } // namespace photoresistor
     namespace mission {

--- a/src/sfr.hpp
+++ b/src/sfr.hpp
@@ -47,6 +47,7 @@ namespace sfr {
         extern std::map<int, int> pinMap;
     } // namespace pins
     namespace photoresistor {
+        extern int val;
         extern bool covered;
     } // namespace photoresistor
     namespace mission {


### PR DESCRIPTION
- Add analog photoresistor value to sfr and normal report
- Declare photoresistor bounds in `constants.hpp` 