### PR TITLE
Normal report unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Constants contains values that will never be changed. This prevents "magic numbe
 
 | Index              | Data                    | Min (if applicable) | Max (if applicable) |
 | ------------------ | ----------------------- | ------------------- | ------------------- |
-| 0                  | 253 (normel report flag)| N/A                 | N/A                 |
+| 0                  | 99 (normel report flag) | N/A                 | N/A                 |
 | 1                  | photoresistor covered   |                     |                     |
 | 2                  | button pressed          |                     |                     |
 | 3                  | mission mode            |                     |                     |
@@ -144,24 +144,18 @@ Constants contains values that will never be changed. This prevents "magic numbe
 | 16                 | gyro\_x                 | 0.0                 | 0.0                 |
 | 17                 | gryo\_y                 | 0.0                 | 0.0                 |
 | 18                 | gyro\_z                 | 0.0                 | 0.0                 |
-| 19                 | temperature             |                     | 200                 |
-| 20                 | temperature mode        |                     |                     |
+| 19                 | light val               |                     |                     |
+| 20                 | temperature             |                     | 200                 |
 | 21                 | solar current           |                     | 500                 |
 | 22                 | in sun                  |                     |                     |
 | 23                 | acs mode                |                     |                     |
 | 24                 | voltage                 | 3                   | 5                   |
 | 25                 | fault mode              |                     |                     |
-| 26                 | mag\_x fault check      |                     |                     |
-| 27                 | mag\_y fault check      |                     |                     |
-| 28                 | mag\_z fault check      |                     |                     |
-| 29                 | gyro\_x fault check     |                     |                     |
-| 30                 | gyro\_y fault check     |                     |                     |
-| 31                 | gyro\_z fault check     |                     |                     |
-| 32                 | temp fault check        |                     |                     |
-| 33                 | voltage fault check     |                     |                     |
-| 34                 | solar fault check       |                     |                     |
-| 35                 | take photo              |                     |                     |
-| 36                 | camera powered          |                     |                     |
+| 26                 | fault1                  |                     |                     |
+| 27                 | fault2                  |                     |                     |
+| 28                 | fault3                  |                     |                     |
+| 29                 | take photo              |                     |                     |
+| 30                 | camera powered          |                     |                     |
 | ...                | opcodes of received commands|                     |                     |
 | report.size() - 2  | 254 (end flag 1)        |                     |                     |
 | report.size() - 2  | 255 (end flag 2)        |                     |                     |

--- a/src/Monitors/NormalReportMonitor.cpp
+++ b/src/Monitors/NormalReportMonitor.cpp
@@ -59,7 +59,6 @@ void NormalReportMonitor::execute()
     sfr::rockblock::normal_report.push_back(faults::fault_1);
     sfr::rockblock::normal_report.push_back(faults::fault_2);
     sfr::rockblock::normal_report.push_back(faults::fault_3);
-    sfr::rockblock::normal_report.push_back(sfr::photoresistor::covered);
     sfr::rockblock::normal_report.push_back(sfr::camera::take_photo);
     sfr::rockblock::normal_report.push_back(sfr::camera::powered);
     int i = 0;

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -62,7 +62,7 @@ namespace constants {
         constexpr size_t max_conseq_read = 3;
 
         constexpr int num_initial_downlinks = 2;
-        constexpr uint8_t start_of_normal_downlink_flag = 253;
+        constexpr uint8_t start_of_normal_downlink_flag = 99;
         constexpr uint8_t end_of_normal_downlink_flag1 = 254;
         constexpr uint8_t end_of_normal_downlink_flag2 = 255;
 

--- a/test/test_report_acknowledge/test_report_acknowledge.cpp
+++ b/test/test_report_acknowledge/test_report_acknowledge.cpp
@@ -8,7 +8,7 @@ void test_normal_report_without_commands()
 {
     NormalReportMonitor normal_report_monitor(0);
     normal_report_monitor.execute();
-    TEST_ASSERT_EQUAL(34, sfr::rockblock::normal_report.size());
+    TEST_ASSERT_EQUAL(33, sfr::rockblock::normal_report.size());
 }
 
 void test_normal_report_with_one_command()
@@ -20,9 +20,9 @@ void test_normal_report_with_one_command()
     sfr::rockblock::waiting_command = true;
     command_monitor.execute();
     normal_report_monitor.execute();
-    TEST_ASSERT_EQUAL(constants::rockblock::mission_mode[0], sfr::rockblock::normal_report[32]);
-    TEST_ASSERT_EQUAL(constants::rockblock::mission_mode[1], sfr::rockblock::normal_report[33]);
-    TEST_ASSERT_EQUAL(36, sfr::rockblock::normal_report.size());
+    TEST_ASSERT_EQUAL(constants::rockblock::mission_mode[0], sfr::rockblock::normal_report[31]);
+    TEST_ASSERT_EQUAL(constants::rockblock::mission_mode[1], sfr::rockblock::normal_report[32]);
+    TEST_ASSERT_EQUAL(35, sfr::rockblock::normal_report.size());
 }
 
 void test_normal_report_with_multiple_commands()
@@ -38,11 +38,11 @@ void test_normal_report_with_multiple_commands()
     sfr::rockblock::waiting_command = true;
     command_monitor.execute();
     normal_report_monitor.execute();
-    TEST_ASSERT_EQUAL(constants::rockblock::mission_mode[0], sfr::rockblock::normal_report[32]);
-    TEST_ASSERT_EQUAL(constants::rockblock::mission_mode[1], sfr::rockblock::normal_report[33]);
-    TEST_ASSERT_EQUAL(constants::rockblock::burnwire_arm[0], sfr::rockblock::normal_report[34]);
-    TEST_ASSERT_EQUAL(constants::rockblock::burnwire_arm[1], sfr::rockblock::normal_report[35]);
-    TEST_ASSERT_EQUAL(38, sfr::rockblock::normal_report.size());
+    TEST_ASSERT_EQUAL(constants::rockblock::mission_mode[0], sfr::rockblock::normal_report[31]);
+    TEST_ASSERT_EQUAL(constants::rockblock::mission_mode[1], sfr::rockblock::normal_report[32]);
+    TEST_ASSERT_EQUAL(constants::rockblock::burnwire_arm[0], sfr::rockblock::normal_report[33]);
+    TEST_ASSERT_EQUAL(constants::rockblock::burnwire_arm[1], sfr::rockblock::normal_report[34]);
+    TEST_ASSERT_EQUAL(37, sfr::rockblock::normal_report.size());
 }
 
 void test_normal_report_with_more_than_15_commands()
@@ -60,13 +60,13 @@ void test_normal_report_with_more_than_15_commands()
     normal_report_monitor.execute();
     i = 0;
     while (i < 15) {
-        TEST_ASSERT_EQUAL(constants::rockblock::burnwire_arm[0], sfr::rockblock::normal_report[32 + (i * 2)]);
-        TEST_ASSERT_EQUAL(constants::rockblock::burnwire_arm[1], sfr::rockblock::normal_report[32 + (i * 2) + 1]);
+        TEST_ASSERT_EQUAL(constants::rockblock::burnwire_arm[0], sfr::rockblock::normal_report[31 + (i * 2)]);
+        TEST_ASSERT_EQUAL(constants::rockblock::burnwire_arm[1], sfr::rockblock::normal_report[31 + (i * 2) + 1]);
         ++i;
     }
-    TEST_ASSERT_EQUAL(constants::rockblock::end_of_normal_downlink_flag1, sfr::rockblock::normal_report[62]);
-    TEST_ASSERT_EQUAL(constants::rockblock::end_of_normal_downlink_flag2, sfr::rockblock::normal_report[63]);
-    TEST_ASSERT_EQUAL(64, sfr::rockblock::normal_report.size());
+    TEST_ASSERT_EQUAL(constants::rockblock::end_of_normal_downlink_flag1, sfr::rockblock::normal_report[61]);
+    TEST_ASSERT_EQUAL(constants::rockblock::end_of_normal_downlink_flag2, sfr::rockblock::normal_report[62]);
+    TEST_ASSERT_EQUAL(63, sfr::rockblock::normal_report.size());
 }
 
 int test_normal_report_acknowledge()

--- a/test/test_report_acknowledge/test_report_acknowledge.cpp
+++ b/test/test_report_acknowledge/test_report_acknowledge.cpp
@@ -11,6 +11,16 @@ void test_normal_report_without_commands()
     TEST_ASSERT_EQUAL(33, sfr::rockblock::normal_report.size());
 }
 
+void test_normal_report_fault()
+{
+    NormalReportMonitor normal_report_monitor(0);
+    sfr::imu::mag_x_average->set_invalid();
+    sfr::imu::mag_z_average->set_invalid();
+    normal_report_monitor.execute();
+    TEST_ASSERT_EQUAL(0b00000101, sfr::rockblock::normal_report[26]);
+    TEST_ASSERT_EQUAL(33, sfr::rockblock::normal_report.size());
+}
+
 void test_normal_report_with_one_command()
 {
     NormalReportMonitor normal_report_monitor(0);
@@ -72,6 +82,7 @@ void test_normal_report_with_more_than_15_commands()
 int test_normal_report_acknowledge()
 {
     UNITY_BEGIN();
+    RUN_TEST(test_normal_report_fault);
     RUN_TEST(test_normal_report_without_commands);
     RUN_TEST(test_normal_report_with_one_command);
     RUN_TEST(test_normal_report_with_multiple_commands);


### PR DESCRIPTION
- Change start of normal report flag to 99 according to the specification of Ria and Eric from ground station
- Modify normal report structure to add fault information with less space
- Edit the README file accordingly