### PR TITLE
Fs 126 camera control

### DIFF
--- a/src/MissionManager.cpp
+++ b/src/MissionManager.cpp
@@ -18,7 +18,7 @@ void MissionManager::execute()
         sfr::mission::current_phase->set_start_time(millis());
     }
 
-    sfr::mission::current_mode->dispatch();
-
     sfr::mission::previous_mode = sfr::mission::current_mode;
+
+    sfr::mission::current_mode->dispatch();
 }

--- a/src/MissionMode.hpp
+++ b/src/MissionMode.hpp
@@ -349,6 +349,7 @@ public:
 
 void exit_signal_phase(MissionMode *mode);
 void exit_detumble_phase(MissionMode *mode);
+void exit_insun_phase(MissionMode *mode);
 void enter_lp(MissionMode *lp_mode);
 void exit_lp(MissionMode *reg_mode);
 void timed_out(MissionMode *next_mode, float max_time);

--- a/src/Monitors/IMUMonitor.cpp
+++ b/src/Monitors/IMUMonitor.cpp
@@ -9,57 +9,58 @@ IMUMonitor::IMUMonitor(unsigned int offset)
 {
     imu = Adafruit_LSM9DS1(constants::imu::CSAG, constants::imu::CSM);
 
+    IMUMonitor::IMU_setup();
+}
+
+void IMUMonitor::IMU_setup()
+{
     if (!imu.begin()) {
+        Serial.println("\n\n\nInitialize failed\n\n\n");
         sfr::imu::successful_init = false;
     } else {
+        Serial.println("\n\n\nInitialize successfully\n\n\n");
         sfr::imu::successful_init = true;
         imu.setupAccel(imu.LSM9DS1_ACCELRANGE_2G);
         imu.setupMag(imu.LSM9DS1_MAGGAIN_4GAUSS);
         imu.setupGyro(imu.LSM9DS1_GYROSCALE_245DPS);
     }
-    sfr::imu::mode = sensor_mode_type::init; // This is already done in sfr.cpp but included for clarity
 }
 
 void IMUMonitor::execute()
 {
-    if (sfr::imu::sample) {
-        switch (sfr::imu::mode) {
-        case sensor_mode_type::init:
-            // Reads result of IMUMonitor initialization and makes the transition to normal or abnormal_init.
-            // This step is needed to wait for sfr.cpp to finish initalizing everything. The SensorReading object
-            // constructors in sfr.cpp are not yet called when attempting to use those objects in the IMUMonitor
-            // initialization.
-            if (sfr::imu::successful_init) {
-                transition_to_normal();
-            } else {
-                transition_to_abnormal_init();
-            }
-            break;
-        case sensor_mode_type::normal:
+    if (sfr::imu::turn_off == true && sfr::imu::powered == true) {
 #ifdef VERBOSE
-            Serial.println("IMU is in Normal Mode");
+        Serial.println("turned off IMU");
 #endif
-            capture_imu_values();
-            break;
-        case sensor_mode_type::abnormal_init:
+        pinMode(constants::imu::CSAG, OUTPUT);
+        pinMode(constants::imu::CSM, OUTPUT);
+        Pins::setPinState(constants::imu::CSAG, LOW);
+        Pins::setPinState(constants::imu::CSM, LOW);
+
+        sfr::imu::powered = false;
+        sfr::imu::turn_off = false;
+    }
+
+    if (sfr::imu::turn_on == true && sfr::imu::powered == false) {
 #ifdef VERBOSE
-            Serial.println("IMU is in Abnormal Initialization Mode");
+        Serial.println("turned on IMU");
 #endif
-            break;
-        case sensor_mode_type::retry:
-#ifdef VERBOSE
-            Serial.println("IMU is in Retry Mode");
-#endif
-            if (!imu.begin()) {
-                transition_to_abnormal_init();
-            } else {
-                transition_to_normal();
-                imu.setupAccel(imu.LSM9DS1_ACCELRANGE_2G);
-                imu.setupMag(imu.LSM9DS1_MAGGAIN_4GAUSS);
-                imu.setupGyro(imu.LSM9DS1_GYROSCALE_245DPS);
-            }
-            break;
+        sfr::imu::turn_on = false; // we don't want to initialize every time
+
+        if (sfr::imu::successful_init) {
+            sfr::imu::powered = true;
+            transition_to_normal();
+        } else {
+            transition_to_abnormal_init();
+            IMUMonitor::IMU_setup();
         }
+    }
+
+    if (sfr::imu::powered == true) {
+#ifdef VERBOSE
+        Serial.println("IMU is on");
+#endif
+        capture_imu_values();
     }
 }
 
@@ -96,6 +97,9 @@ void IMUMonitor::capture_imu_values()
     sfr::imu::gyro_x = gyro.gyro.x;
     sfr::imu::gyro_y = gyro.gyro.y;
     sfr::imu::gyro_z = gyro.gyro.z;
+
+    // for testing
+    Serial.printf("\n\nx : %f, y: %f, z: %f\n\n", sfr::imu::gyro_x, sfr::imu::gyro_y, sfr::imu::gyro_z);
 
     sfr::imu::gyro_x_value->set_value(sfr::imu::gyro_x);
     sfr::imu::gyro_y_value->set_value(sfr::imu::gyro_y);
@@ -188,7 +192,6 @@ void IMUMonitor::transition_to_normal()
     // updates imu mode to normal
     // faults are cleared
     // all check flags are set to true
-    sfr::imu::mode = sensor_mode_type::normal;
     sfr::imu::mag_x_average->set_valid();
     sfr::imu::mag_y_average->set_valid();
     sfr::imu::mag_z_average->set_valid();
@@ -204,7 +207,6 @@ void IMUMonitor::transition_to_abnormal_init()
     // updates imu mode to abnormal_init
     // trips fault
     // all check flags are set to false
-    sfr::imu::mode = sensor_mode_type::abnormal_init;
     sfr::imu::mag_x_average->set_invalid();
     sfr::imu::mag_y_average->set_invalid();
     sfr::imu::mag_z_average->set_invalid();
@@ -213,12 +215,4 @@ void IMUMonitor::transition_to_abnormal_init()
     sfr::imu::gyro_z_average->set_invalid();
     sfr::imu::acc_x_average->set_invalid();
     sfr::imu::acc_y_average->set_invalid();
-}
-
-void IMUMonitor::transition_to_retry()
-{
-    // updates imu mode to retry
-    // this mode will call either transition_to_normal or transition_to_abnormal_init, which will flip flags
-    // called when command to retry processes
-    sfr::imu::mode = sensor_mode_type::retry;
 }

--- a/src/Monitors/IMUMonitor.hpp
+++ b/src/Monitors/IMUMonitor.hpp
@@ -2,7 +2,6 @@
 #define IMU_MONITOR_HPP_
 
 #include "sfr.hpp"
-
 class IMUMonitor : public TimedControlTask<void>
 {
 public:
@@ -10,11 +9,12 @@ public:
     void execute();
     Adafruit_LSM9DS1 imu;
 
+private:
+    void IMU_setup();
+    void IMU_init();
     void transition_to_normal();
     void transition_to_abnormal_init();
     void transition_to_retry();
-
-private:
     void capture_imu_values();
 };
 

--- a/src/sfr.cpp
+++ b/src/sfr.cpp
@@ -147,6 +147,7 @@ namespace sfr {
         bool arm = false;
         burnwire_mode_type mode = burnwire_mode_type::standby;
         int attempts = 0;
+        int attempts_limit = 10;
         int start_time = 0;
         int camera_attempts = 0;
         int burn_time = 500;
@@ -163,6 +164,8 @@ namespace sfr {
         // Initialization
         camera_init_mode_type init_mode = camera_init_mode_type::awaiting;
         uint8_t start_progress = 0;
+        uint8_t failed_times = 0;
+        uint8_t failed_limit = 5;
         uint64_t step_time = 0;
         uint64_t init_start_time = 0;
         uint64_t init_timeout = 12000;
@@ -234,6 +237,9 @@ namespace sfr {
     namespace imu {
         sensor_mode_type mode = sensor_mode_type::init;
         bool successful_init = true;
+        bool turn_off = false; // action variable
+        bool turn_on = false;  // action variable
+        bool powered = false;  // state variable
 
         float mag_x = 0.0;
         float mag_y = 0.0;
@@ -317,8 +323,8 @@ namespace sfr {
         std::deque<float> voltage_buffer;
         SensorReading *voltage_average = new SensorReading(fault_index_type::voltage, 0.0, false);
         // TODO
-        float acceptable_battery;
-        float min_battery;
+        float acceptable_battery = 3.9;
+        float min_battery = 3.75;
     } // namespace battery
     namespace fault {
         fault_mode_type mode = fault_mode_type::active;

--- a/src/sfr.hpp
+++ b/src/sfr.hpp
@@ -132,6 +132,7 @@ namespace sfr {
         extern bool arm;
         extern burnwire_mode_type mode;
         extern int attempts;
+        extern int attempts_limit;
         extern int start_time;
         extern int camera_attempts;
         extern int burn_time;
@@ -147,6 +148,8 @@ namespace sfr {
 
         extern camera_init_mode_type init_mode;
         extern uint8_t start_progress;
+        extern uint8_t failed_times;
+        extern uint8_t failed_limit;
         extern uint64_t step_time;
         extern uint64_t init_start_time;
         extern uint64_t init_timeout;
@@ -219,6 +222,9 @@ namespace sfr {
     namespace imu {
         extern sensor_mode_type mode;
         extern bool successful_init;
+        extern bool turn_off; // action variable
+        extern bool turn_on;  // action variable
+        extern bool powered;  // state variable
 
         extern float mag_x;
         extern float mag_y;

--- a/test/test_mission_manager/test_mission_manager.cpp
+++ b/test/test_mission_manager/test_mission_manager.cpp
@@ -2,7 +2,8 @@
 #include "sfr.hpp"
 #include <unity.h>
 
-void reset(){
+void reset()
+{
     sfr::imu::gyro_z_average->set_value(0);
     sfr::imu::gyro_x_average->set_value(0);
     sfr::imu::gyro_y_average->set_value(0);
@@ -12,7 +13,7 @@ void reset(){
     sfr::mission::inSun->set_start_time(millis());
     sfr::detumble::max_time = 4 * constants::time::one_hour;
     sfr::boot::max_time = constants::time::one_day;
-    sfr::battery::voltage_average->set_value(sfr::battery::acceptable_battery+.1);
+    sfr::battery::voltage_average->set_value(sfr::battery::acceptable_battery + .1);
     sfr::rockblock::max_check_signal_time = constants::time::one_minute;
     sfr::acs::on_time = constants::time::one_minute;
     sfr::mission::acs_transmit_cycle_time = constants::time::one_hour;
@@ -36,69 +37,77 @@ void reset_lp(MissionManager mission_manager, MissionMode *mode)
     TEST_ASSERT_EQUAL(mode->get_id(), sfr::mission::current_mode->get_id());
 }
 
-void reset_transmit(MissionManager mission_manager, MissionMode *transmitMode){
+void reset_transmit(MissionManager mission_manager, MissionMode *transmitMode)
+{
     reset();
     sfr::mission::current_mode = transmitMode;
     sfr::battery::voltage_average->set_valid();
     mission_manager.execute();
-    TEST_ASSERT_EQUAL(transmitMode->get_id(), sfr::mission::current_mode->get_id()); 
+    TEST_ASSERT_EQUAL(transmitMode->get_id(), sfr::mission::current_mode->get_id());
 }
 
-void test_boot_settings(){
+void test_boot_settings()
+{
     TEST_ASSERT_EQUAL(sfr::rockblock::sleep_mode, true);
     TEST_ASSERT_EQUAL(sfr::acs::off, true);
     TEST_ASSERT_EQUAL(sfr::imu::sample, false);
 }
 
-void test_transmit_settings(){
+void test_transmit_settings()
+{
     TEST_ASSERT_EQUAL(sfr::rockblock::sleep_mode, false);
     TEST_ASSERT_EQUAL(sfr::acs::off, true);
     TEST_ASSERT_EQUAL(sfr::imu::sample, false);
 }
 
-void test_low_power_settings(){
+void test_low_power_settings()
+{
     TEST_ASSERT_EQUAL(sfr::rockblock::sleep_mode, false);
     TEST_ASSERT_EQUAL(sfr::acs::off, true);
     TEST_ASSERT_EQUAL(sfr::imu::sample, false);
 }
 
-void test_normal_settings(){
+void test_normal_settings()
+{
     TEST_ASSERT_EQUAL(sfr::rockblock::sleep_mode, true);
     TEST_ASSERT_EQUAL(sfr::acs::off, false);
     TEST_ASSERT_EQUAL(sfr::imu::sample, true);
 }
 
-void test_low_power_detumble_spin_settings(){
+void test_low_power_detumble_spin_settings()
+{
     TEST_ASSERT_EQUAL(sfr::rockblock::sleep_mode, true);
     TEST_ASSERT_EQUAL(sfr::acs::off, true);
     TEST_ASSERT_EQUAL(sfr::imu::sample, false);
 }
 
-void reset(MissionManager mission_manager, MissionMode *mode){
-    if(mode->get_type() == mode_type::TRANSMIT){
+void reset(MissionManager mission_manager, MissionMode *mode)
+{
+    if (mode->get_type() == mode_type::TRANSMIT) {
         reset_transmit(mission_manager, mode);
-    } else if (mode->get_type() == mode_type::LP){
+    } else if (mode->get_type() == mode_type::LP) {
         reset_lp(mission_manager, mode);
         test_low_power_settings();
-    } else if (mode->get_type() == mode_type::NORMAL){
+    } else if (mode->get_type() == mode_type::NORMAL) {
         reset_normal(mission_manager, mode);
         test_normal_settings();
-    } else if(mode->get_id() == 4){
+    } else if (mode->get_id() == 4) {
         reset_lp(mission_manager, mode);
         test_low_power_detumble_spin_settings();
     } else if (mode->get_id() == 16) {
         reset();
         sfr::mission::current_mode = sfr::mission::lowPowerInSun;
         sfr::battery::voltage_average->set_valid();
-        sfr::battery::voltage_average->set_value(sfr::battery::acceptable_battery-.1);
+        sfr::battery::voltage_average->set_value(sfr::battery::acceptable_battery - .1);
         mission_manager.execute();
-        TEST_ASSERT_EQUAL(sfr::mission::lowPowerInSun->get_id(), sfr::mission::current_mode->get_id()); 
+        TEST_ASSERT_EQUAL(sfr::mission::lowPowerInSun->get_id(), sfr::mission::current_mode->get_id());
     } else {
         reset_normal(mission_manager, mode);
     }
 }
 
-void test_exit_acs(MissionManager mission_manager, MissionMode *currentMode, MissionMode *nextMode){
+void test_exit_acs(MissionManager mission_manager, MissionMode *currentMode, MissionMode *nextMode)
+{
     reset(mission_manager, currentMode);
 
     // do not exit if acs if time has not been reached
@@ -109,7 +118,7 @@ void test_exit_acs(MissionManager mission_manager, MissionMode *currentMode, Mis
     TEST_ASSERT_EQUAL(currentMode->get_id(), sfr::mission::current_mode->get_id());
 
     reset(mission_manager, currentMode);
-    
+
     // exit if time has been reached
     sfr::acs::on_time = 5;
     currentMode->set_start_time(millis());
@@ -120,7 +129,8 @@ void test_exit_acs(MissionManager mission_manager, MissionMode *currentMode, Mis
     reset(mission_manager, currentMode);
 }
 
-void test_enter_acs(MissionManager mission_manager, MissionMode *currentMode, MissionMode *nextMode){
+void test_enter_acs(MissionManager mission_manager, MissionMode *currentMode, MissionMode *nextMode)
+{
     reset(mission_manager, currentMode);
 
     // stay in transmit mode if not enough time has passed
@@ -132,19 +142,20 @@ void test_enter_acs(MissionManager mission_manager, MissionMode *currentMode, Mi
     TEST_ASSERT_EQUAL(currentMode->get_id(), sfr::mission::current_mode->get_id());
 
     reset(mission_manager, currentMode);
-    
+
     // exit transmit mode if acs transmit time has passed
     sfr::mission::acs_transmit_cycle_time = 10;
     sfr::acs::on_time = 5;
     currentMode->set_start_time(millis());
-    delay(sfr::mission::acs_transmit_cycle_time-sfr::acs::on_time);
+    delay(sfr::mission::acs_transmit_cycle_time - sfr::acs::on_time);
     mission_manager.execute();
     TEST_ASSERT_EQUAL(nextMode->get_id(), sfr::mission::current_mode->get_id());
 
     reset(mission_manager, currentMode);
 }
 
-void test_exit_lp(MissionManager mission_manager, MissionMode *lpMode, MissionMode *currentMode){
+void test_exit_lp(MissionManager mission_manager, MissionMode *lpMode, MissionMode *currentMode)
+{
     reset(mission_manager, currentMode);
     mission_manager.execute();
     reset(mission_manager, currentMode);
@@ -157,7 +168,7 @@ void test_exit_lp(MissionManager mission_manager, MissionMode *lpMode, MissionMo
     reset(mission_manager, lpMode);
 
     // exit if battery voltage is high enough
-    sfr::battery::voltage_average->set_value(sfr::battery::acceptable_battery+.1);
+    sfr::battery::voltage_average->set_value(sfr::battery::acceptable_battery + .1);
     sfr::battery::voltage_average->set_valid();
     mission_manager.execute();
     TEST_ASSERT_EQUAL(currentMode->get_id(), sfr::mission::current_mode->get_id());
@@ -166,7 +177,7 @@ void test_exit_lp(MissionManager mission_manager, MissionMode *lpMode, MissionMo
 
     // don't exit if voltage sensor resolves itself but battery voltage does not
     sfr::battery::voltage_average->set_valid();
-    sfr::battery::voltage_average->set_value(sfr::battery::min_battery-.1);
+    sfr::battery::voltage_average->set_value(sfr::battery::min_battery - .1);
     mission_manager.execute();
     TEST_ASSERT_EQUAL(lpMode->get_id(), sfr::mission::current_mode->get_id());
 
@@ -174,14 +185,15 @@ void test_exit_lp(MissionManager mission_manager, MissionMode *lpMode, MissionMo
 
     // don't exit if voltage sensor resolves itself but battery voltage does not
     sfr::battery::voltage_average->set_invalid();
-    sfr::battery::voltage_average->set_value(sfr::battery::acceptable_battery+.1);
+    sfr::battery::voltage_average->set_value(sfr::battery::acceptable_battery + .1);
     mission_manager.execute();
     TEST_ASSERT_EQUAL(lpMode->get_id(), sfr::mission::current_mode->get_id());
 
     reset(mission_manager, currentMode);
 }
 
-void test_enter_lp(MissionManager mission_manager, MissionMode *lpMode, MissionMode *normalMode){
+void test_enter_lp(MissionManager mission_manager, MissionMode *lpMode, MissionMode *normalMode)
+{
     reset(mission_manager, normalMode);
 
     // exit if voltage sensor fails
@@ -192,7 +204,7 @@ void test_enter_lp(MissionManager mission_manager, MissionMode *lpMode, MissionM
     reset(mission_manager, normalMode);
 
     // exit if battery voltage is too low
-    sfr::battery::voltage_average->set_value(sfr::battery::min_battery-.1);
+    sfr::battery::voltage_average->set_value(sfr::battery::min_battery - .1);
     mission_manager.execute();
     TEST_ASSERT_EQUAL(lpMode->get_id(), sfr::mission::current_mode->get_id());
 
@@ -200,17 +212,18 @@ void test_enter_lp(MissionManager mission_manager, MissionMode *lpMode, MissionM
 
     // exit if battery voltage is too low and voltage sensor fails
     sfr::battery::voltage_average->set_invalid();
-    sfr::battery::voltage_average->set_value(sfr::battery::min_battery-.1);
+    sfr::battery::voltage_average->set_value(sfr::battery::min_battery - .1);
     mission_manager.execute();
     TEST_ASSERT_EQUAL(lpMode->get_id(), sfr::mission::current_mode->get_id());
 
     reset(mission_manager, normalMode);
 }
 
-void test_exit_signal_phase(MissionManager mission_manager, MissionMode *currentMode, MissionMode *nextMode){
+void test_exit_signal_phase(MissionManager mission_manager, MissionMode *currentMode, MissionMode *nextMode)
+{
     reset(mission_manager, currentMode);
     sfr::aliveSignal::downlinked = false;
-    
+
     // exit if downlinked
     sfr::aliveSignal::downlinked = true;
     mission_manager.execute();
@@ -218,29 +231,30 @@ void test_exit_signal_phase(MissionManager mission_manager, MissionMode *current
 
     reset(mission_manager, currentMode);
 
-    //exit if reached max number of hard faults
+    // exit if reached max number of hard faults
     sfr::aliveSignal::num_hard_faults = sfr::aliveSignal::max_downlink_hard_faults;
     mission_manager.execute();
     TEST_ASSERT_EQUAL(nextMode->get_id(), sfr::mission::current_mode->get_id());
 
     reset(mission_manager, currentMode);
 
-    //exit if signal quality has not reached acceptable level in one minute
+    // exit if signal quality has not reached acceptable level in one minute
     sfr::rockblock::max_check_signal_time = 5;
     delay(sfr::rockblock::max_check_signal_time);
     mission_manager.execute();
     TEST_ASSERT_EQUAL(nextMode->get_id(), sfr::mission::current_mode->get_id());
-    
+
     reset(mission_manager, currentMode);
 
-    //don't exit if none of the above conditions are met
+    // don't exit if none of the above conditions are met
     mission_manager.execute();
     TEST_ASSERT_EQUAL(currentMode->get_id(), sfr::mission::current_mode->get_id());
 
     reset(mission_manager, currentMode);
 }
 
-void test_exit_detumble_phase(MissionManager mission_manager, MissionMode *currentMode, MissionMode *nextMode){
+void test_exit_detumble_phase(MissionManager mission_manager, MissionMode *currentMode, MissionMode *nextMode)
+{
     reset(mission_manager, currentMode);
 
     // exit if stabilization times out
@@ -252,16 +266,38 @@ void test_exit_detumble_phase(MissionManager mission_manager, MissionMode *curre
 
     reset(mission_manager, currentMode);
 
-    //exit if imu determines stable
+    // exit if imu determines stable
     sfr::imu::gyro_z_average->set_value(sfr::detumble::min_stable_gyro_z);
     sfr::imu::gyro_x_average->set_value(sfr::detumble::max_stable_gyro_x);
     sfr::imu::gyro_y_average->set_value(sfr::detumble::max_stable_gyro_y);
     mission_manager.execute();
     TEST_ASSERT_EQUAL(nextMode->get_id(), sfr::mission::current_mode->get_id());
 
-    //exit if imu determines unstable
+    // exit if imu determines unstable
     sfr::imu::gyro_x_average->set_value(sfr::detumble::min_unstable_gyro_x);
     sfr::imu::gyro_y_average->set_value(sfr::detumble::min_unstable_gyro_y);
+    mission_manager.execute();
+    TEST_ASSERT_EQUAL(nextMode->get_id(), sfr::mission::current_mode->get_id());
+
+    reset(mission_manager, currentMode);
+}
+
+void test_exit_insun_phase(MissionManager mission_manager, MissionMode *currentMode, MissionMode *nextMode)
+{
+    reset(mission_manager, currentMode);
+
+    // exit if the CubeSat is in sun (Temperature sensor readings are valid and the temperature determines the CubeSat is in sun)
+    sfr::temperature::temp_c_average->set_valid();
+    sfr::temperature::in_sun = true;
+    mission_manager.execute();
+    TEST_ASSERT_EQUAL(nextMode->get_id(), sfr::mission::current_mode->get_id());
+
+    reset(mission_manager, currentMode);
+
+    // exit if the CubeSat is in sun (Temperature sensor readings are invalid, current sensor readings are valid and current determines the CubeSat is in sun)
+    sfr::temperature::temp_c_average->set_invalid();
+    sfr::current::solar_current_average->set_valid();
+    sfr::current::in_sun = true;
     mission_manager.execute();
     TEST_ASSERT_EQUAL(nextMode->get_id(), sfr::mission::current_mode->get_id());
 
@@ -295,7 +331,6 @@ void test_exit_alive_signal()
     test_exit_signal_phase(mission_manager, sfr::mission::aliveSignal, sfr::mission::detumbleSpin);
 }
 
-
 void test_exit_low_power_alive_signal()
 {
     MissionManager mission_manager(0);
@@ -303,7 +338,6 @@ void test_exit_low_power_alive_signal()
     test_exit_lp(mission_manager, sfr::mission::lowPowerAliveSignal, sfr::mission::aliveSignal);
     test_exit_signal_phase(mission_manager, sfr::mission::lowPowerAliveSignal, sfr::mission::lowPowerDetumbleSpin);
 }
-
 
 void test_exit_detumble_spin()
 {
@@ -323,52 +357,76 @@ void test_exit_low_power_detumble_spin()
     test_exit_detumble_phase(mission_manager, sfr::mission::lowPowerDetumbleSpin, sfr::mission::lowPower);
 }
 
+void test_exit_normal_insun()
+{
+    MissionManager mission_manager(0);
+    reset(mission_manager, sfr::mission::normalInSun);
+    test_exit_insun_phase(mission_manager, sfr::mission::normalInSun, sfr::mission::bootCamera);
+}
+
+void test_exit_transmit_insun()
+{
+    MissionManager mission_manager(0);
+    reset(mission_manager, sfr::mission::transmitInSun);
+    test_exit_insun_phase(mission_manager, sfr::mission::transmitInSun, sfr::mission::bootCamera);
+}
+
+void test_exit_voltageFailure_insun()
+{
+    MissionManager mission_manager(0);
+    reset(mission_manager, sfr::mission::voltageFailureInSun);
+    test_exit_insun_phase(mission_manager, sfr::mission::voltageFailureInSun, sfr::mission::bootCamera);
+}
+
 void test_standard_phase(MissionMode *normalMode, MissionMode *lpMode, MissionMode *transmitMode)
 {
-    //test exit normal
+    // test exit normal
     MissionManager mission_manager(0);
     reset(mission_manager, normalMode);
 
     test_enter_lp(mission_manager, lpMode, normalMode);
     test_exit_acs(mission_manager, normalMode, transmitMode);
 
-    //test exit low power
-    //if entered low power mode from normal mode go back to normal mode
+    // test exit low power
+    // if entered low power mode from normal mode go back to normal mode
     test_exit_lp(mission_manager, lpMode, normalMode);
 
-    //if entered low power mode from transmit mode go back to transmit mode
+    // if entered low power mode from transmit mode go back to transmit mode
     test_exit_lp(mission_manager, lpMode, transmitMode);
 
-    //test exit transmit
+    // test exit transmit
     test_enter_lp(mission_manager, lpMode, transmitMode);
     test_enter_acs(mission_manager, transmitMode, normalMode);
-
 }
 
-void test_standby() {
+void test_standby()
+{
     test_standard_phase(sfr::mission::normal, sfr::mission::lowPower, sfr::mission::transmit);
 }
 
-void test_deployment() {
+void test_deployment()
+{
     test_standard_phase(sfr::mission::normalDeployment, sfr::mission::lowPowerDeployment, sfr::mission::transmitDeployment);
 }
 
-void test_armed() {
+void test_armed()
+{
     test_standard_phase(sfr::mission::normalArmed, sfr::mission::lowPowerArmed, sfr::mission::transmitArmed);
 }
 
-void test_enter_lp_insun(MissionManager mission_manager, MissionMode *currentMode){
+void test_enter_lp_insun(MissionManager mission_manager, MissionMode *currentMode)
+{
     reset(mission_manager, currentMode);
 
     // exit if voltage sensor fails
-    sfr::battery::voltage_average->set_invalid();    
+    sfr::battery::voltage_average->set_invalid();
     mission_manager.execute();
     TEST_ASSERT_EQUAL(sfr::mission::voltageFailureInSun->get_id(), sfr::mission::current_mode->get_id());
 
     reset(mission_manager, currentMode);
 
     // exit if battery voltage is too low
-    sfr::battery::voltage_average->set_value(sfr::battery::min_battery-.1);
+    sfr::battery::voltage_average->set_value(sfr::battery::min_battery - .1);
     mission_manager.execute();
     TEST_ASSERT_EQUAL(sfr::mission::lowPowerInSun->get_id(), sfr::mission::current_mode->get_id());
 
@@ -376,31 +434,34 @@ void test_enter_lp_insun(MissionManager mission_manager, MissionMode *currentMod
 
     // exit if battery voltage is too low and voltage sensor fails
     sfr::battery::voltage_average->set_invalid();
-    sfr::battery::voltage_average->set_value(sfr::battery::min_battery-.1);
+    sfr::battery::voltage_average->set_value(sfr::battery::min_battery - .1);
     mission_manager.execute();
     TEST_ASSERT_EQUAL(sfr::mission::voltageFailureInSun->get_id(), sfr::mission::current_mode->get_id());
 
     reset(mission_manager, currentMode);
 }
 
-void test_exit_insun_normal(){
+void test_exit_insun_normal()
+{
     MissionManager mission_manager(0);
     test_enter_lp_insun(mission_manager, sfr::mission::normalInSun);
     test_exit_acs(mission_manager, sfr::mission::normalInSun, sfr::mission::transmitInSun);
 }
 
-void test_exit_insun_transmit(){
+void test_exit_insun_transmit()
+{
     MissionManager mission_manager(0);
     test_enter_lp_insun(mission_manager, sfr::mission::transmitInSun);
     test_enter_acs(mission_manager, sfr::mission::transmitInSun, sfr::mission::normalInSun);
 }
 
-void test_exit_insun_lp(){
+void test_exit_insun_lp()
+{
     MissionManager mission_manager(0);
     reset(mission_manager, sfr::mission::lowPowerInSun);
 
     // exit if battery voltage is high enough
-    sfr::battery::voltage_average->set_value(sfr::battery::acceptable_battery+.1);
+    sfr::battery::voltage_average->set_value(sfr::battery::acceptable_battery + .1);
     sfr::battery::voltage_average->set_valid();
     mission_manager.execute();
     TEST_ASSERT_EQUAL(sfr::mission::transmitInSun->get_id(), sfr::mission::current_mode->get_id());
@@ -409,19 +470,20 @@ void test_exit_insun_lp(){
 
     // enter voltage fault state even if battery is valid
     sfr::battery::voltage_average->set_invalid();
-    sfr::battery::voltage_average->set_value(sfr::battery::acceptable_battery+.1);
+    sfr::battery::voltage_average->set_value(sfr::battery::acceptable_battery + .1);
     mission_manager.execute();
     TEST_ASSERT_EQUAL(sfr::mission::voltageFailureInSun->get_id(), sfr::mission::current_mode->get_id());
 
     reset(mission_manager, sfr::mission::lowPowerInSun);
 }
 
-void test_exit_insun_voltage_fault(){
+void test_exit_insun_voltage_fault()
+{
     MissionManager mission_manager(0);
     reset(mission_manager, sfr::mission::voltageFailureInSun);
 
     // don't exit if battery voltage is high enough and voltage reading is still invalid
-    sfr::battery::voltage_average->set_value(sfr::battery::acceptable_battery+.1);
+    sfr::battery::voltage_average->set_value(sfr::battery::acceptable_battery + .1);
     sfr::battery::voltage_average->set_invalid();
     mission_manager.execute();
     TEST_ASSERT_EQUAL(sfr::mission::voltageFailureInSun->get_id(), sfr::mission::current_mode->get_id());
@@ -430,13 +492,13 @@ void test_exit_insun_voltage_fault(){
 
     // exit if voltage is valid and go to normal
     sfr::battery::voltage_average->set_valid();
-    sfr::battery::voltage_average->set_value(sfr::battery::acceptable_battery+.1);
+    sfr::battery::voltage_average->set_value(sfr::battery::acceptable_battery + .1);
     mission_manager.execute();
     TEST_ASSERT_EQUAL(sfr::mission::normalInSun->get_id(), sfr::mission::current_mode->get_id());
 
     reset(mission_manager, sfr::mission::voltageFailureInSun);
 }
-    
+
 int test_mission_manager()
 {
     UNITY_BEGIN();


### PR DESCRIPTION
Verified Zehua's changes to the camera deployment task, with minor changes to retry logic.

Tested successful camera capture + writing / expected failure behavior on the flatsat in the following cases:

1. Standard photo capture
2. Change resolution
3. Dead wire
4. SD card removed
5. Timeout during camera initialization
6. Success after x number of failed initialization attempts (<max failed attempts)

SD card writing and image downlink modes of photo capture tested.