### PR TITLE
Handle overflowing normal report and manage the storage of received commands

### DIFF
--- a/src/Monitors/CommandMonitor.cpp
+++ b/src/Monitors/CommandMonitor.cpp
@@ -12,6 +12,10 @@ void CommandMonitor::execute()
         while (!sfr::rockblock::processed_commands.empty()) { // (Only Valid Commands - cmd.isValid())
             RockblockCommand *command = sfr::rockblock::processed_commands.front();
             command->execute(); // Polymorphic Command Execution
+            sfr::rockblock::commands_received.push_front(command->f_opcode);
+            if (sfr::rockblock::commands_received.size() > constants::rockblock::normal_report_command_default_max) {
+                sfr::rockblock::commands_received.pop_back();
+            }
             sfr::rockblock::processed_commands.pop_front();
         }
         sfr::rockblock::waiting_command = false;

--- a/src/Monitors/NormalReportMonitor.cpp
+++ b/src/Monitors/NormalReportMonitor.cpp
@@ -6,19 +6,18 @@ NormalReportMonitor::NormalReportMonitor(unsigned int offset)
 {
 }
 
-std::queue<uint8_t> NormalReportMonitor::commands_received;
-
 void NormalReportMonitor::execute()
 {
+    std::deque<uint8_t> empty_normal_report;
+    std::swap(sfr::rockblock::normal_report, empty_normal_report);
     // TODO serialize sensor data and push to NormalReport buffer. FS-161
-    /*int i = 0;
-    while (!commands_received.empty() && i < 30) {
-        sfr::rockblock::normal_report.push_back(commands_received.front());
-        commands_received.pop();
-        ++i;
-    } // Writes opcodes to normal report; two indices constitute one opcode since each opcode is 2-byte
-    std::queue<uint8_t> empty;
-    std::swap(commands_received, empty); // Clear the queue after each normal report is generated
+    int i = 0;
+    auto current_command = sfr::rockblock::commands_received.cbegin();
+    while (current_command != sfr::rockblock::commands_received.cend() && i < sfr::rockblock::normal_report_command_max) {
+        sfr::rockblock::normal_report.push_back(*current_command);
+        i++;
+    }
+    sfr::rockblock::normal_report_command_curr = i;
     sfr::rockblock::normal_report.push_back(constants::rockblock::end_of_normal_downlink_flag1);
-    sfr::rockblock::normal_report.push_back(constants::rockblock::end_of_normal_downlink_flag2);*/
+    sfr::rockblock::normal_report.push_back(constants::rockblock::end_of_normal_downlink_flag2);
 }

--- a/src/Monitors/NormalReportMonitor.hpp
+++ b/src/Monitors/NormalReportMonitor.hpp
@@ -8,8 +8,6 @@
 class NormalReportMonitor : public TimedControlTask<void>
 {
 public:
-    static std::queue<uint8_t> commands_received; // Queue to hold commands received since last report
-
     NormalReportMonitor(unsigned int offset);
     void execute();
 };

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -27,6 +27,8 @@ namespace constants {
         constexpr int camera_max_attempts = 50;
     } // namespace burnwire
     namespace rockblock {
+        constexpr int normal_report_command_default_max = 15;
+
         constexpr int content_length = 68;
 
         constexpr int sleep_pin = 19;

--- a/src/sfr.cpp
+++ b/src/sfr.cpp
@@ -187,6 +187,10 @@ namespace sfr {
         std::deque<uint8_t> camera_report;
         std::deque<uint8_t> imu_report;
 
+        uint8_t normal_report_command_curr = 0;
+        uint8_t normal_report_command_max = constants::rockblock::normal_report_command_default_max;
+        std::deque<uint8_t> commands_received;
+
         char buffer[constants::rockblock::buffer_size] = {0};
         int camera_commands[99][constants::rockblock::command_len] = {};
         uint32_t camera_max_fragments[99] = {};

--- a/src/sfr.hpp
+++ b/src/sfr.hpp
@@ -207,6 +207,10 @@ namespace sfr {
         extern std::deque<uint8_t> camera_report;
         extern std::deque<uint8_t> imu_report;
 
+        extern uint8_t normal_report_command_curr;
+        extern uint8_t normal_report_command_max;
+        extern std::deque<uint8_t> commands_received;
+
         extern char buffer[constants::rockblock::buffer_size];
         extern int camera_commands[99][constants::rockblock::command_len];
         extern uint32_t camera_max_fragments[99];


### PR DESCRIPTION
Manage storage of received commands in a "Circular Buffer like" way (I ended up using deque instead of my Circular Buffer class for testing simplicity) - (Serves as a queue pushing old commands out when reaching max size of 15)

Overflowing normal report fix:
1. Lock max commands once the size has been set to prevent overflow of the expected size. 
2. Clear the received commands once the report has been downlinked.
3.  Reset size to default max once receipt of downlink has been received.

