### PR TITLE
Change low power exit logic to strict greater than

### DIFF
--- a/src/MissionMode.cpp
+++ b/src/MissionMode.cpp
@@ -360,7 +360,7 @@ void exit_lp(MissionMode *reg_mode)
 {
     float voltage;
 
-    if (sfr::battery::voltage_average->get_value(&voltage) && voltage >= sfr::battery::acceptable_battery) {
+    if (sfr::battery::voltage_average->get_value(&voltage) && voltage > sfr::battery::acceptable_battery) {
         sfr::mission::current_mode = reg_mode;
     }
 }


### PR DESCRIPTION
# FS-173 Fix Battery Monitor

Fixes #[173](https://ssdsalphacubesat.atlassian.net/jira/software/c/projects/FS/boards/1?modal=detail&selectedIssue=FS-173). 

### Summary of changes
- Deleted an "=" to prevent rapid fluctuations between LP and Normal states

### Testing
No significant testing needed as it is a one character change, and this issue will be separately addressed when the voltage thresholds for transitioning are finalized in the sfr.

### SFR Changes
None

### Documentation Evidence
Inline documentation is enough for deleting a single "=".