### PR TITLE
Fs 171

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -29,7 +29,7 @@ board_build.f_cpu = 24000000L
 build_flags = -D PRINT
 lib_ldf_mode = deep
 extra_scripts = extra_script.py
-test_port = /dev/ttyACM1
+test_port = /dev/ttyACM0
 
 [env:debug-linux40]
 platform = teensy

--- a/platformio.ini
+++ b/platformio.ini
@@ -29,7 +29,7 @@ board_build.f_cpu = 24000000L
 build_flags = -D PRINT
 lib_ldf_mode = deep
 extra_scripts = extra_script.py
-test_port = /dev/ttyACM0
+test_port = /dev/ttyACM1
 
 [env:debug-linux40]
 platform = teensy

--- a/src/MissionManager.cpp
+++ b/src/MissionManager.cpp
@@ -8,6 +8,13 @@ MissionManager::MissionManager(unsigned int offset)
 
 void MissionManager::execute()
 {
+    sfr::mission::current_phase = modeToPhase(sfr::mission::current_mode);
+
+    if (sfr::mission::current_phase->get_id() == sfr::mission::armed->get_id() && (millis() - sfr::mission::current_phase->start_time) > sfr::burnwire::armed_time) {
+        sfr::mission::current_mode = sfr::mission::normalDeployment;
+        sfr::mission::current_phase = modeToPhase(sfr::mission::current_mode);
+    }
+
     if (sfr::mission::previous_mode->get_id() != sfr::mission::current_mode->get_id()) {
         sfr::mission::current_mode->set_start_time(millis());
         sfr::mission::current_mode->transition_to();
@@ -19,6 +26,26 @@ void MissionManager::execute()
     }
 
     sfr::mission::previous_mode = sfr::mission::current_mode;
+    sfr::mission::previous_phase = modeToPhase(sfr::mission::current_mode);
 
     sfr::mission::current_mode->dispatch();
+}
+
+Phase *MissionManager::modeToPhase(MissionMode *mission)
+{
+    if (mission->get_id() == sfr::mission::detumbleSpin->get_id() || mission->get_id() == sfr::mission::lowPowerDetumbleSpin->get_id()) {
+        return sfr::mission::stabilization;
+    } else if (mission->get_id() == sfr::mission::normal->get_id() || mission->get_id() == sfr::mission::transmit->get_id() || mission->get_id() == sfr::mission::lowPower->get_id()) {
+        return sfr::mission::standby;
+    } else if (mission->get_id() == sfr::mission::normalDeployment->get_id() || mission->get_id() == sfr::mission::transmitDeployment->get_id() || mission->get_id() == sfr::mission::lowPowerDeployment->get_id()) {
+        return sfr::mission::deployment;
+    } else if (mission->get_id() == sfr::mission::normalArmed->get_id() || mission->get_id() == sfr::mission::transmitArmed->get_id() || mission->get_id() == sfr::mission::lowPowerArmed->get_id()) {
+        return sfr::mission::armed;
+    } else if (mission->get_id() == sfr::mission::normalInSun->get_id() || mission->get_id() == sfr::mission::transmitInSun->get_id() || mission->get_id() == sfr::mission::lowPowerInSun->get_id() || mission->get_id() == sfr::mission::voltageFailureInSun->get_id()) {
+        return sfr::mission::inSun;
+    } else if (mission->get_id() == sfr::mission::bootCamera->get_id() || mission->get_id() == sfr::mission::mandatoryBurns->get_id() || mission->get_id() == sfr::mission::regularBurns->get_id() || mission->get_id() == sfr::mission::photo->get_id()) {
+        return sfr::mission::firing;
+    } else {
+        return sfr::mission::initialization;
+    }
 }

--- a/src/MissionManager.cpp
+++ b/src/MissionManager.cpp
@@ -29,7 +29,6 @@ void MissionManager::execute()
     sfr::mission::previous_phase = modeToPhase(sfr::mission::current_mode);
 
     sfr::mission::current_mode->dispatch();
-
 }
 
 Phase *MissionManager::modeToPhase(MissionMode *mission)

--- a/src/MissionManager.cpp
+++ b/src/MissionManager.cpp
@@ -10,6 +10,10 @@ void MissionManager::execute()
 {
     sfr::mission::current_phase = modeToPhase(sfr::mission::current_mode);
 
+    if (sfr::mission::previous_phase->get_id() != sfr::mission::current_phase->get_id()) {
+        sfr::mission::current_phase->set_start_time(millis());
+    }
+
     if (sfr::mission::current_phase->get_id() == sfr::mission::armed->get_id() && (millis() - sfr::mission::current_phase->start_time) > sfr::burnwire::armed_time) {
         sfr::mission::current_mode = sfr::mission::normalDeployment;
         sfr::mission::current_phase = modeToPhase(sfr::mission::current_mode);
@@ -21,14 +25,11 @@ void MissionManager::execute()
         sfr::mission::mode_history.push_front(sfr::mission::current_mode->get_id());
     }
 
-    if (sfr::mission::previous_phase->get_id() != sfr::mission::current_phase->get_id()) {
-        sfr::mission::current_phase->set_start_time(millis());
-    }
-
     sfr::mission::previous_mode = sfr::mission::current_mode;
     sfr::mission::previous_phase = modeToPhase(sfr::mission::current_mode);
 
     sfr::mission::current_mode->dispatch();
+
 }
 
 Phase *MissionManager::modeToPhase(MissionMode *mission)

--- a/src/MissionManager.hpp
+++ b/src/MissionManager.hpp
@@ -12,6 +12,7 @@ class MissionManager : public TimedControlTask<void>
 {
 public:
     MissionManager(unsigned int offset);
+    Phase *modeToPhase(MissionMode *mission);
     void execute();
 };
 

--- a/test/test_command_timeout/test_command_timeout.cpp
+++ b/test/test_command_timeout/test_command_timeout.cpp
@@ -18,7 +18,7 @@ void test_armed_timeout()
     TEST_ASSERT_EQUAL(sfr::mission::armed->get_id(), sfr::mission::current_phase->get_id());
 
     // Check that armed command timed out
-    delay(FAKE_ARMED_TIME);
+    delay(FAKE_ARMED_TIME + 1);
     mission_manager.execute();
     TEST_ASSERT_EQUAL(sfr::mission::deployment->get_id(), sfr::mission::current_phase->get_id());
     

--- a/test/test_command_timeout/test_command_timeout.cpp
+++ b/test/test_command_timeout/test_command_timeout.cpp
@@ -1,0 +1,50 @@
+#include <unity.h>
+#include "MissionManager.hpp"
+#include "Arduino.h"
+
+#define FAKE_ARMED_TIME 5000
+
+void test_armed_timeout()
+{
+    MissionManager mission_manager(0);
+
+    // Lower actual armed phase timeout
+    sfr::burnwire::armed_time.set(FAKE_ARMED_TIME);
+    TEST_ASSERT_EQUAL(FAKE_ARMED_TIME, sfr::burnwire::armed_time);
+
+    // Set current mission mode to an armed phase mode
+    sfr::mission::current_mode = sfr::mission::normalArmed;
+    mission_manager.execute();
+    TEST_ASSERT_EQUAL(sfr::mission::armed->get_id(), sfr::mission::current_phase->get_id());
+
+    // Check that armed command timed out
+    delay(FAKE_ARMED_TIME);
+    mission_manager.execute();
+    TEST_ASSERT_EQUAL(sfr::mission::deployment->get_id(), sfr::mission::current_phase->get_id());
+    
+}
+
+int test_commands()
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_armed_timeout);
+    return UNITY_END();
+}
+
+#ifdef DESKTOP
+int main()
+{
+    return test_commands();
+}
+#else
+#include <Arduino.h>
+void setup()
+{
+    delay(5000);
+    Serial.begin(9600);
+    delay(5000);
+    test_commands();
+}
+
+void loop() {}
+#endif

--- a/test/test_mission_mode_phase_conversion/test_mission_mode_phase_conversion.cpp
+++ b/test/test_mission_mode_phase_conversion/test_mission_mode_phase_conversion.cpp
@@ -1,0 +1,70 @@
+#include <unity.h>
+#include "MissionManager.hpp"
+#include "Arduino.h"
+
+void test_conversion()
+{
+    MissionManager mission_manager(0);
+
+    // Initialization
+    TEST_ASSERT_EQUAL(sfr::mission::initialization->get_id(), mission_manager.modeToPhase(sfr::mission::boot)->get_id());
+    TEST_ASSERT_EQUAL(sfr::mission::initialization->get_id(), mission_manager.modeToPhase(sfr::mission::aliveSignal)->get_id());
+    TEST_ASSERT_EQUAL(sfr::mission::initialization->get_id(), mission_manager.modeToPhase(sfr::mission::lowPowerAliveSignal)->get_id());
+
+    // Stabilization
+    TEST_ASSERT_EQUAL(sfr::mission::stabilization->get_id(), mission_manager.modeToPhase(sfr::mission::detumbleSpin)->get_id());
+    TEST_ASSERT_EQUAL(sfr::mission::stabilization->get_id(), mission_manager.modeToPhase(sfr::mission::lowPowerDetumbleSpin)->get_id());
+
+    // Standby
+    TEST_ASSERT_EQUAL(sfr::mission::standby->get_id(), mission_manager.modeToPhase(sfr::mission::normal)->get_id());
+    TEST_ASSERT_EQUAL(sfr::mission::standby->get_id(), mission_manager.modeToPhase(sfr::mission::transmit)->get_id());
+    TEST_ASSERT_EQUAL(sfr::mission::standby->get_id(), mission_manager.modeToPhase(sfr::mission::lowPower)->get_id());
+
+    // Deployment
+    TEST_ASSERT_EQUAL(sfr::mission::deployment->get_id(), mission_manager.modeToPhase(sfr::mission::normalDeployment)->get_id());
+    TEST_ASSERT_EQUAL(sfr::mission::deployment->get_id(), mission_manager.modeToPhase(sfr::mission::transmitDeployment)->get_id());
+    TEST_ASSERT_EQUAL(sfr::mission::deployment->get_id(), mission_manager.modeToPhase(sfr::mission::lowPowerDeployment)->get_id());
+
+    // Armed
+    TEST_ASSERT_EQUAL(sfr::mission::armed->get_id(), mission_manager.modeToPhase(sfr::mission::normalArmed)->get_id());
+    TEST_ASSERT_EQUAL(sfr::mission::armed->get_id(), mission_manager.modeToPhase(sfr::mission::transmitArmed)->get_id());
+    TEST_ASSERT_EQUAL(sfr::mission::armed->get_id(), mission_manager.modeToPhase(sfr::mission::lowPowerArmed)->get_id());
+
+    // In Sun
+    TEST_ASSERT_EQUAL(sfr::mission::inSun->get_id(), mission_manager.modeToPhase(sfr::mission::normalInSun)->get_id());
+    TEST_ASSERT_EQUAL(sfr::mission::inSun->get_id(), mission_manager.modeToPhase(sfr::mission::transmitInSun)->get_id());
+    TEST_ASSERT_EQUAL(sfr::mission::inSun->get_id(), mission_manager.modeToPhase(sfr::mission::lowPowerInSun)->get_id());
+    TEST_ASSERT_EQUAL(sfr::mission::inSun->get_id(), mission_manager.modeToPhase(sfr::mission::voltageFailureInSun)->get_id());
+
+    // Firing
+    TEST_ASSERT_EQUAL(sfr::mission::firing->get_id(), mission_manager.modeToPhase(sfr::mission::bootCamera)->get_id());
+    TEST_ASSERT_EQUAL(sfr::mission::firing->get_id(), mission_manager.modeToPhase(sfr::mission::mandatoryBurns)->get_id());
+    TEST_ASSERT_EQUAL(sfr::mission::firing->get_id(), mission_manager.modeToPhase(sfr::mission::regularBurns)->get_id());
+    TEST_ASSERT_EQUAL(sfr::mission::firing->get_id(), mission_manager.modeToPhase(sfr::mission::photo)->get_id());
+    
+}
+
+int test_mission_mode_phase_conversion()
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_conversion);
+    return UNITY_END();
+}
+
+#ifdef DESKTOP
+int main()
+{
+    return test_mission_mode_phase_conversion();
+}
+#else
+#include <Arduino.h>
+void setup()
+{
+    delay(5000);
+    Serial.begin(9600);
+    delay(5000);
+    test_mission_mode_phase_conversion();
+}
+
+void loop() {}
+#endif


### PR DESCRIPTION
# Timeout for Armed Command

Fixes #. ([FS-171](https://ssdsalphacubesat.atlassian.net/browse/FS-171?atlOrigin=eyJpIjoiOTQxNGUxZWZhMGU2NDc4NDkzMjgwNzYyYjdiN2U4NDgiLCJwIjoiaiJ9))

### Summary of changes
- Add method to get phase based on current mission mode 
- Update current phase based on current mission mode
- Check how long we have been in the armed phase and timeout (go back to deployment phase) is necessary

### Testing
Wrote unit tests to confirm that method that converts mission mode to phase is accurate.
Wrote unit tests to confirm that the armed phase times out.

### SFR Changes
None

### Documentation Evidence
Documented in [Mission Mode Diagram](https://github.com/Alpha-CubeSat/oop-flight-code/wiki/Mission-Modes#diagram-with-entrance-and-exit-conditions)

[FS-171]: https://ssdsalphacubesat.atlassian.net/browse/FS-171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ