### PR TITLE
Changes based on end to end test

### DIFF
--- a/src/Control Tasks/CameraControlTask.cpp
+++ b/src/Control Tasks/CameraControlTask.cpp
@@ -86,7 +86,7 @@ void CameraControlTask::execute()
         }
 
 #ifdef VERBOSE_CAM
-            Serial.println("");
+        Serial.println("");
 #endif
 
         jpglen -= bytesToRead;

--- a/src/Control Tasks/CameraControlTask.cpp
+++ b/src/Control Tasks/CameraControlTask.cpp
@@ -75,17 +75,19 @@ void CameraControlTask::execute()
         for (int i = 0; i < bytesToRead; i++) {
             if (buffer[i] < 16) {
                 imgFile.print(0, HEX);
-#ifdef VERBOSE
+#ifdef VERBOSE_CAM
                 Serial.print(0, HEX);
 #endif
             }
             imgFile.print(buffer[i], HEX);
-#ifdef VERBOSE
+#ifdef VERBOSE_CAM
             Serial.print(buffer[i], HEX);
 #endif
         }
 
-        Serial.println("");
+#ifdef VERBOSE_CAM
+            Serial.println("");
+#endif
 
         jpglen -= bytesToRead;
         imgFile.close();

--- a/src/Control Tasks/RockblockControlTask.cpp
+++ b/src/Control Tasks/RockblockControlTask.cpp
@@ -93,6 +93,14 @@ void RockblockControlTask::dispatch_standby()
     }
 #endif
 
+#ifdef VERBOSE_RB
+    if (sfr::rockblock::ready_status) {
+        Serial.print("Rockblock Ready to Downlink\n");
+    } else {
+        Serial.print("Rockblock Not Ready to Downlink\n");
+    }
+#endif
+
     if ((sfr::rockblock::ready_status || sfr::rockblock::waiting_message) && !sfr::rockblock::sleep_mode) {
         transition_to(rockblock_mode_type::send_at);
         Pins::setPinState(constants::rockblock::sleep_pin, HIGH);

--- a/src/Monitors/CurrentMonitor.cpp
+++ b/src/Monitors/CurrentMonitor.cpp
@@ -8,6 +8,12 @@ CurrentMonitor::CurrentMonitor(unsigned int offset)
 
 void CurrentMonitor::execute()
 {
+    if(!initialized){
+        sfr::photoresistor::light_val_average_standby->set_valid();
+        sfr::photoresistor::light_val_average_deployment->set_valid();
+        initialized = true;
+    }
+    
     uint16_t val = analogRead(constants::current::pin);
     float voltage = (val * constants::current::voltage_ref) / constants::current::resolution;
     float milliamps = 1000 * voltage / (constants::current::load * constants::current::shunt);

--- a/src/Monitors/CurrentMonitor.cpp
+++ b/src/Monitors/CurrentMonitor.cpp
@@ -8,12 +8,12 @@ CurrentMonitor::CurrentMonitor(unsigned int offset)
 
 void CurrentMonitor::execute()
 {
-    if(!initialized){
+    if (!initialized) {
         sfr::photoresistor::light_val_average_standby->set_valid();
         sfr::photoresistor::light_val_average_deployment->set_valid();
         initialized = true;
     }
-    
+
     uint16_t val = analogRead(constants::current::pin);
     float voltage = (val * constants::current::voltage_ref) / constants::current::resolution;
     float milliamps = 1000 * voltage / (constants::current::load * constants::current::shunt);

--- a/src/Monitors/CurrentMonitor.hpp
+++ b/src/Monitors/CurrentMonitor.hpp
@@ -9,6 +9,10 @@ class CurrentMonitor : public TimedControlTask<void>
 public:
     CurrentMonitor(unsigned int offset);
     void execute();
+
+private:
+    bool initialized = false;
+    
 };
 
 #endif

--- a/src/Monitors/CurrentMonitor.hpp
+++ b/src/Monitors/CurrentMonitor.hpp
@@ -12,7 +12,6 @@ public:
 
 private:
     bool initialized = false;
-    
 };
 
 #endif

--- a/src/Monitors/PhotoresistorMonitor.cpp
+++ b/src/Monitors/PhotoresistorMonitor.cpp
@@ -7,7 +7,7 @@ PhotoresistorMonitor::PhotoresistorMonitor(unsigned int offset)
 
 void PhotoresistorMonitor::execute()
 {
-    if(!initialized){
+    if (!initialized) {
         sfr::photoresistor::light_val_average_standby->set_valid();
         sfr::photoresistor::light_val_average_deployment->set_valid();
         initialized = true;

--- a/src/Monitors/PhotoresistorMonitor.cpp
+++ b/src/Monitors/PhotoresistorMonitor.cpp
@@ -7,6 +7,12 @@ PhotoresistorMonitor::PhotoresistorMonitor(unsigned int offset)
 
 void PhotoresistorMonitor::execute()
 {
+    if(!initialized){
+        sfr::photoresistor::light_val_average_standby->set_valid();
+        sfr::photoresistor::light_val_average_deployment->set_valid();
+        initialized = true;
+    }
+
     float val = analogRead(constants::photoresistor::pin);
     bool possible_uncovered = false;
 

--- a/src/Monitors/PhotoresistorMonitor.hpp
+++ b/src/Monitors/PhotoresistorMonitor.hpp
@@ -16,6 +16,7 @@ public:
 
 private:
     void capture_photoresistor_value();
+    bool initialized = false;
 };
 
 #endif

--- a/src/Monitors/TemperatureMonitor.cpp
+++ b/src/Monitors/TemperatureMonitor.cpp
@@ -8,7 +8,7 @@ TemperatureMonitor::TemperatureMonitor(unsigned int offset)
 
 void TemperatureMonitor::execute()
 {
-    if(!initialized){
+    if (!initialized) {
         sfr::temperature::temp_c_average->set_valid();
         sfr::temperature::temp_c_value->set_valid();
         initialized = true;

--- a/src/Monitors/TemperatureMonitor.cpp
+++ b/src/Monitors/TemperatureMonitor.cpp
@@ -8,6 +8,12 @@ TemperatureMonitor::TemperatureMonitor(unsigned int offset)
 
 void TemperatureMonitor::execute()
 {
+    if(!initialized){
+        sfr::temperature::temp_c_average->set_valid();
+        sfr::temperature::temp_c_value->set_valid();
+        initialized = true;
+    }
+
     float val = (((analogRead(constants::temperature::pin) * 3.3) / 1023) - .5) * 100;
     sfr::temperature::temp_c_average->set_value(val);
     sfr::temperature::temp_c_value->set_value(val);

--- a/src/Monitors/TemperatureMonitor.hpp
+++ b/src/Monitors/TemperatureMonitor.hpp
@@ -10,6 +10,7 @@ class TemperatureMonitor : public TimedControlTask<void>
 public:
     TemperatureMonitor(unsigned int offset);
     void execute();
+
 private:
     bool initialized = false;
 };

--- a/src/Monitors/TemperatureMonitor.hpp
+++ b/src/Monitors/TemperatureMonitor.hpp
@@ -10,6 +10,8 @@ class TemperatureMonitor : public TimedControlTask<void>
 public:
     TemperatureMonitor(unsigned int offset);
     void execute();
+private:
+    bool initialized = false;
 };
 
 #endif

--- a/src/RockblockSimulator.cpp
+++ b/src/RockblockSimulator.cpp
@@ -19,6 +19,11 @@ RockblockSimulator::RockblockSimulator()
     // end of command upload flag 1 00
     // end of command upload flag 2 FA
     // insert("1901111111110000000000FA");
+
+    // COMMANDS TO DEPLOY BURNWIRE
+    //insert("3333111111111111111100FA");
+    //insert("4444111111111111111100FA");
+    //insert("5555111111111111111100FA");
 }
 
 void RockblockSimulator::begin(uint32_t baud)

--- a/src/RockblockSimulator.cpp
+++ b/src/RockblockSimulator.cpp
@@ -21,9 +21,9 @@ RockblockSimulator::RockblockSimulator()
     // insert("1901111111110000000000FA");
 
     // COMMANDS TO DEPLOY BURNWIRE
-    //insert("3333111111111111111100FA");
-    //insert("4444111111111111111100FA");
-    //insert("5555111111111111111100FA");
+    // insert("3333111111111111111100FA");
+    // insert("4444111111111111111100FA");
+    // insert("5555111111111111111100FA");
 }
 
 void RockblockSimulator::begin(uint32_t baud)

--- a/src/SensorReading.hpp
+++ b/src/SensorReading.hpp
@@ -17,7 +17,7 @@ private:
     float max;                // max valid value
     float min;                // min valid value
     std::deque<float> buffer; // buffer used to store the raw values
-    bool valid;               // if SensorReading is valid
+    bool valid = false;               // if SensorReading is valid
     bool repeated_values(std::deque<float> *buffer, float val);
 
 public:

--- a/src/SensorReading.hpp
+++ b/src/SensorReading.hpp
@@ -17,7 +17,7 @@ private:
     float max;                // max valid value
     float min;                // min valid value
     std::deque<float> buffer; // buffer used to store the raw values
-    bool valid = false;               // if SensorReading is valid
+    bool valid = false;       // if SensorReading is valid
     bool repeated_values(std::deque<float> *buffer, float val);
 
 public:

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -57,17 +57,17 @@ namespace constants {
             // Deploy Command
             constexpr uint16_t sfr_field_opcode_deploy = 0x3333;
 
-            // Fire Command
-            constexpr uint16_t sfr_field_opcode_fire = 0x4444;
-
             // Arm Command
-            constexpr uint16_t sfr_field_opcode_arm = 0x5555;
+            constexpr uint16_t sfr_field_opcode_arm = 0x4444;
+
+            // Fire Command
+            constexpr uint16_t sfr_field_opcode_fire = 0x5555;
 
         } // namespace opcodes
     }     // namespace rockblock
     namespace temperature {
         constexpr int pin = 39;
-        constexpr float in_sun_val = 40;
+        constexpr float in_sun_val = 30;
     } // namespace temperature
     namespace current {
         constexpr int pin = 22;


### PR DESCRIPTION
# Changes based on end to end test

### Summary of changes
- Modified initialization of monitors without normal initialization that contains sensor readings to initially validate sensor readings.
- Added additional debugging prints.

TODO: Fix normal report bug that causes processed opcodes to be repeated. Debug why create camera report hangs.

### Testing
Tested during end to end test. Ran code on flatsat to ensure sensor readings were validated correctly.

### SFR Changes
None

### Documentation Evidence
Documentation on wiki is sufficient.