### PR TITLE
fix repeating opcodes in normal report

### DIFF
--- a/src/Control Tasks/RockblockControlTask.cpp
+++ b/src/Control Tasks/RockblockControlTask.cpp
@@ -441,6 +441,7 @@ void RockblockControlTask::dispatch_process_command()
             } else {
                 // Invalid Command Recieved
                 // TODO: What Goes Here @Lauren
+                Serial.println("SAT INFO: invalid command");
             }
         }
 

--- a/src/Monitors/CommandMonitor.cpp
+++ b/src/Monitors/CommandMonitor.cpp
@@ -13,6 +13,7 @@ void CommandMonitor::execute()
             RockblockCommand *command = sfr::rockblock::processed_commands.front();
             command->execute(); // Polymorphic Command Execution
             sfr::rockblock::commands_received.push_front(command->f_opcode);
+            sfr::rockblock::commands_received.push_front(command->f_opcode >> 8);
             if (sfr::rockblock::commands_received.size() > constants::rockblock::normal_report_command_default_max) {
                 sfr::rockblock::commands_received.pop_back();
             }

--- a/src/Monitors/NormalReportMonitor.cpp
+++ b/src/Monitors/NormalReportMonitor.cpp
@@ -94,11 +94,6 @@ void NormalReportMonitor::execute()
         std::advance(current_command, 1);
         j++;
     }
-
-    while (j < sfr::rockblock::normal_report_command_max) {
-        sfr::rockblock::normal_report.push_back(0x00);
-        j++;
-    }
     sfr::rockblock::normal_report_command_curr = j;
     sfr::rockblock::normal_report.push_back(constants::rockblock::end_of_normal_downlink_flag1);
     sfr::rockblock::normal_report.push_back(constants::rockblock::end_of_normal_downlink_flag2);

--- a/src/Monitors/NormalReportMonitor.cpp
+++ b/src/Monitors/NormalReportMonitor.cpp
@@ -91,6 +91,12 @@ void NormalReportMonitor::execute()
     auto current_command = sfr::rockblock::commands_received.cbegin();
     while (current_command != sfr::rockblock::commands_received.cend() && j < sfr::rockblock::normal_report_command_max) {
         sfr::rockblock::normal_report.push_back(*current_command);
+        std::advance(current_command, 1);
+        j++;
+    }
+
+    while (j < sfr::rockblock::normal_report_command_max) {
+        sfr::rockblock::normal_report.push_back(0x00);
         j++;
     }
     sfr::rockblock::normal_report_command_curr = j;


### PR DESCRIPTION
# FS-183 Fix repeating opcodes in normal report

Fixes [FS-183](https://ssdsalphacubesat.atlassian.net/browse/FS-183?atlOrigin=eyJpIjoiOTQyNDgxYjE3MTcwNDcwMGFkYzVmN2MzMzkxMzlmNDQiLCJwIjoiaiJ9). 

### Summary of changes
- Added iteration through received commands so that the normal report does not repeat the same opcode fragment until max is reached
- Fix Command Monitor so that both bytes of each opcode are written to the normal report
- Add debug print statement

### Testing
Tested with Rockblock Simulator to advance through mission modes with uplinked commands, and observing proper normal report formation.

### SFR Changes
None

### Documentation Evidence
Existing documentation is sufficient

[FS-183]: https://ssdsalphacubesat.atlassian.net/browse/FS-183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ