### PR TITLE
FS-159 verify pin states

### DIFF
--- a/src/Pins.cpp
+++ b/src/Pins.cpp
@@ -33,7 +33,6 @@ void Pins::setInitialPinStates()
     pinMode(constants::temperature::pin, INPUT);
     pinMode(constants::current::pin, INPUT);
     pinMode(constants::burnwire::first_pin, OUTPUT);
-    pinMode(constants::battery::allow_measurement_pin, OUTPUT);
     pinMode(constants::burnwire::second_pin, OUTPUT);
     pinMode(constants::rockblock::sleep_pin, OUTPUT);
 
@@ -52,7 +51,6 @@ void Pins::setInitialPinStates()
     Pins::setPinState(constants::acs::STBXYpin, LOW);
     Pins::setPinState(constants::acs::STBZpin, LOW);
     Pins::setPinState(constants::burnwire::first_pin, LOW);
-    Pins::setPinState(constants::battery::allow_measurement_pin, HIGH);
     Pins::setPinState(constants::burnwire::second_pin, LOW);
     Pins::setPinState(constants::rockblock::sleep_pin, HIGH);
 }

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -101,7 +101,6 @@ namespace constants {
     } // namespace acs
     namespace battery {
         constexpr int voltage_value_pin = 32;
-        constexpr int allow_measurement_pin = 36;
         constexpr float voltage_ref = 3.3;
         constexpr int resolution = 1023;
         constexpr int r1 = 4700;

--- a/src/sfr.cpp
+++ b/src/sfr.cpp
@@ -302,12 +302,6 @@ namespace sfr {
     } // namespace button
     namespace pins {
         std::map<int, int> pinMap = {
-            {constants::photoresistor::pin, LOW},
-            {constants::burnwire::first_pin, LOW},
-            {constants::burnwire::second_pin, LOW},
-            {constants::rockblock::sleep_pin, LOW},
-            {constants::temperature::pin, LOW},
-            {constants::current::pin, LOW},
             {constants::acs::xPWMpin, LOW},
             {constants::acs::yPWMpin, LOW},
             {constants::acs::zPWMpin, LOW},
@@ -317,14 +311,20 @@ namespace sfr {
             {constants::acs::xout2, LOW},
             {constants::acs::zout1, LOW},
             {constants::acs::zout2, LOW},
-            {constants::acs::STBXYpin, LOW},
-            {constants::acs::STBZpin, LOW},
-            {constants::battery::voltage_value_pin, LOW},
-            {constants::battery::allow_measurement_pin, HIGH},
             {constants::camera::power_on_pin, LOW},
             {constants::camera::rx, LOW},
             {constants::camera::tx, LOW},
-            {constants::button::button_pin, LOW}};
+            {constants::button::button_pin, HIGH},
+            {constants::battery::voltage_value_pin, LOW},
+            {constants::acs::STBXYpin, LOW},
+            {constants::acs::STBZpin, LOW},
+            {constants::photoresistor::pin, LOW},
+            {constants::temperature::pin, LOW},
+            {constants::current::pin, LOW},
+            {constants::burnwire::first_pin, LOW},
+            {constants::burnwire::second_pin, LOW},
+            {constants::rockblock::sleep_pin, LOW}};
+
     } // namespace pins
     namespace eeprom {
         // OP Codes 2800


### PR DESCRIPTION
# FS-159 verify initial pin states

Fixes [FS-159](https://ssdsalphacubesat.atlassian.net/browse/FS-159?atlOrigin=eyJpIjoiNDA1ZjhkODVmNjdiNDI5ZjhmZTIzYmU3YTkwMjBmYTEiLCJwIjoiaiJ9).

### Summary of changes
- Verified and corrected initial pin states
- Minor changes to sfr pinMap for readability
- Removed references to obsolete "allow measurement pin"

### Testing
No changes to functional code.

### SFR Changes
Described in summary.

### Documentation Evidence
Existing documentation is sufficient

[FS-159]: https://ssdsalphacubesat.atlassian.net/browse/FS-159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ