### PR TITLE
Fs 184 latent turn on turn off

### DIFF
--- a/src/Control Tasks/CameraControlTask.cpp
+++ b/src/Control Tasks/CameraControlTask.cpp
@@ -7,6 +7,14 @@ CameraControlTask::CameraControlTask(unsigned int offset)
 
 void CameraControlTask::execute()
 {
+    // handle latent turn on / turn off variables
+    if (sfr::camera::turn_off == true && sfr::camera::powered == false) {
+        sfr::camera::turn_off = false;
+    }
+    if (sfr::camera::turn_on == true && sfr::camera::powered == true) {
+        sfr::camera::turn_on = false;
+    }
+
     if (sfr::camera::take_photo == true && sfr::camera::powered == true) {
         if (!adaCam.takePicture()) {
             Serial.println("Failed to snap!");

--- a/src/Monitors/IMUMonitor.cpp
+++ b/src/Monitors/IMUMonitor.cpp
@@ -31,12 +31,21 @@ void IMUMonitor::IMU_init()
 
 void IMUMonitor::execute()
 {
+    // handle latent turn on / turn off variables
+    if (sfr::imu::turn_off == true && sfr::imu::powered == false) {
+        sfr::imu::turn_off = false;
+    }
+    if (sfr::imu::turn_on == true && sfr::imu::powered == true) {
+        sfr::imu::turn_on = false;
+    }
+
     if (sfr::imu::turn_on == true && sfr::imu::powered == false) {
 #ifdef VERBOSE
         Serial.println("turned on IMU");
 #endif
         IMUMonitor::IMU_init();
         if (sfr::imu::init_mode == (uint16_t)sensor_init_mode_type::complete) {
+            sfr::imu::turn_on = false;
             transition_to_normal();
         } else {
             if (sfr::imu::failed_times == sfr::imu::failed_limit) {


### PR DESCRIPTION
# Latent Turn On / Turn Off

Fixes [#FS-184](https://ssdsalphacubesat.atlassian.net/browse/FS-184?atlOrigin=eyJpIjoiODdiYjFhN2FlYmUzNGNiMThlZWQ4NDk5YjczYTA5NmMiLCJwIjoiaiJ9)

### Summary of changes
Ensure state of turn on / turn off to match the status of powered for the camera and IMU.

### Testing
Passes existing IMU and Camera monitor unit tests.

### SFR Changes
None

### Documentation Evidence
IMU and Camera documentation is sufficient.