### PR TITLE
remove extraneous delay

### DIFF
--- a/src/Control Tasks/CameraControlTask.cpp
+++ b/src/Control Tasks/CameraControlTask.cpp
@@ -130,16 +130,13 @@ void CameraControlTask::camera_init()
             Pins::setPinState(constants::camera::power_on_pin, HIGH);
             sfr::camera::start_progress++;
             break;
-        case 2:                                                                // step 2 - call begin method
-            if (millis() - sfr::camera::step_time >= sfr::camera::begin_delay) // need to determine this delay
-            {
-                if (adaCam.begin()) {
-                    Serial.println("powered on camera");
-                    sfr::camera::step_time = millis();
-                    sfr::camera::start_progress++;
-                } else {
-                    Serial.println("not receiving serial response");
-                }
+        case 2: // step 2 - call begin method
+            if (adaCam.begin()) {
+                Serial.println("powered on camera");
+                sfr::camera::step_time = millis();
+                sfr::camera::start_progress++;
+            } else {
+                Serial.println("not receiving serial response");
             }
             break;
         case 3: // step 3  - set resolution

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -258,8 +258,7 @@ namespace constants {
         static constexpr unsigned int camera_step_time_offset = camera_start_progress_offset + 2;
         static constexpr unsigned int camera_init_start_time_offset = camera_step_time_offset + 5;
         static constexpr unsigned int camera_init_timeout_offset = camera_init_start_time_offset + 5;
-        static constexpr unsigned int camera_begin_delay_offset = camera_init_timeout_offset + 5;
-        static constexpr unsigned int camera_resolution_set_delay_offset = camera_begin_delay_offset + 5;
+        static constexpr unsigned int camera_resolution_set_delay_offset = camera_init_start_time_offset + 5;
         static constexpr unsigned int camera_resolution_get_delay_offset = camera_resolution_set_delay_offset + 5;
         static constexpr unsigned int camera_init_mode_offset = camera_resolution_get_delay_offset + 5;
         static constexpr unsigned int camera_mode_offset = camera_init_mode_offset + 3;

--- a/src/sfr.cpp
+++ b/src/sfr.cpp
@@ -147,7 +147,6 @@ namespace sfr {
         SFRField<uint32_t> step_time = SFRField<uint32_t>(0, 0x2006, constants::eeprom::camera_step_time_offset, true);
         SFRField<uint32_t> init_start_time = SFRField<uint32_t>(0, 0x2007, constants::eeprom::camera_init_start_time_offset, true);
         SFRField<uint32_t> init_timeout = SFRField<uint32_t>(12000, 0x2008, constants::eeprom::camera_init_timeout_offset, true);
-        SFRField<uint32_t> begin_delay = SFRField<uint32_t>(100, 0x2009, constants::eeprom::camera_begin_delay_offset, true);
         SFRField<uint32_t> resolution_set_delay = SFRField<uint32_t>(500, 0x2010, constants::eeprom::camera_resolution_set_delay_offset, true);
         SFRField<uint32_t> resolution_get_delay = SFRField<uint32_t>(200, 0x2011, constants::eeprom::camera_resolution_get_delay_offset, true);
 

--- a/src/sfr.hpp
+++ b/src/sfr.hpp
@@ -166,7 +166,6 @@ namespace sfr {
         extern SFRField<uint32_t> step_time;
         extern SFRField<uint32_t> init_start_time;
         extern SFRField<uint32_t> init_timeout;
-        extern SFRField<uint32_t> begin_delay;
         extern SFRField<uint32_t> resolution_set_delay;
         extern SFRField<uint32_t> resolution_get_delay;
 


### PR DESCRIPTION
# Remove camera delay

### Summary of changes
- Removed references to a delay in the camera boot cycle that was unnecessary

### Testing
Tested on flatsat after removing delay, camera still boots.

### SFR Changes
Deleted sfr::<zero-width space>camera::begin_delay

### Documentation Evidence
N/A