### PR TITLE
post-deployment logic fixes

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -53,6 +53,16 @@ board_build.f_cpu = 24000000L
 build_flags = -D VERBOSE
 lib_ldf_mode = deep
 
+[env:teensy35_E2E]
+platform = teensy
+board = teensy35
+framework = arduino
+upload_protocol = teensy-cli
+test_build_src = true
+board_build.f_cpu = 24000000L
+build_flags = -D VERBOSE_RB -D E2E_TESTING
+lib_ldf_mode = deep
+
 [env:simulator]
 platform = teensy
 board = teensy35
@@ -60,7 +70,7 @@ framework = arduino
 upload_protocol = teensy-cli
 test_build_src = true
 board_build.f_cpu = 24000000L
-build_flags = -D SIMULATOR -D VERBOSE_RB -D E2E_TESTING
+build_flags = -D SIMULATOR -D VERBOSE_RB
 lib_ldf_mode = deep
 
 [env:simulator40]

--- a/platformio.ini
+++ b/platformio.ini
@@ -60,7 +60,7 @@ framework = arduino
 upload_protocol = teensy-cli
 test_build_src = true
 board_build.f_cpu = 24000000L
-build_flags = -D SIMULATOR -D VERBOSE_RB
+build_flags = -D SIMULATOR -D VERBOSE_RB -D E2E_TESTING
 lib_ldf_mode = deep
 
 [env:simulator40]

--- a/src/Control Tasks/CameraControlTask.cpp
+++ b/src/Control Tasks/CameraControlTask.cpp
@@ -14,7 +14,7 @@ void CameraControlTask::execute()
             Serial.println("\n\n\nPicture taken!\n\n\n");
             jpglen = adaCam.frameLength();
             Serial.println("Camera frame length: " + String(jpglen));
-            Serial.println("##### Start wrting the picture to SD card #####");
+            Serial.println("##### Start writing the picture to SD card #####");
             if (jpglen > 0) {
                 sfr::camera::take_photo = false;
             }
@@ -184,8 +184,8 @@ void CameraControlTask::transition_to_normal()
     // updates camera mode to normal
     sfr::camera::mode = (uint16_t)sensor_mode_type::normal;
 #ifdef VERBOSE
-    Serial.println("camera initialization successful");
 #endif
+    Serial.println("camera initialization successful");
 }
 
 void CameraControlTask::transition_to_abnormal_init()

--- a/src/Control Tasks/RockblockControlTask.cpp
+++ b/src/Control Tasks/RockblockControlTask.cpp
@@ -10,6 +10,10 @@ RockblockControlTask::RockblockControlTask(unsigned int offset)
 void RockblockControlTask::execute()
 {
     rockblock_mode_type mode = static_cast<rockblock_mode_type>(sfr::rockblock::mode.get());
+#ifdef E2E_TESTING
+    Serial.print("Mission Mode: ");
+    Serial.println(sfr::mission::current_mode->get_id());
+#endif
     switch (mode) {
     case rockblock_mode_type::standby:
         dispatch_standby();

--- a/src/MainControlLoop.cpp
+++ b/src/MainControlLoop.cpp
@@ -24,6 +24,10 @@ MainControlLoop::MainControlLoop()
     delay(1000);
 }
 
+#ifdef E2E_TESTING
+bool first_iter = true;
+#endif
+
 void MainControlLoop::execute()
 {
     delay(200); // To prolong the speed of the main control loop to ensure correct RockBlock reads. Can reduce in the future.
@@ -32,6 +36,12 @@ void MainControlLoop::execute()
     faults::fault_2 = 0;
     faults::fault_3 = 0;
 
+#ifdef E2E_TESTING
+    if (first_iter) {
+        first_iter = false;
+        sfr::mission::current_mode = sfr::mission::normal;
+    }
+#endif
     clock_manager.execute();
     mission_manager.execute_on_time();
     battery_monitor.execute_on_time();

--- a/src/MissionManager.cpp
+++ b/src/MissionManager.cpp
@@ -22,6 +22,10 @@ void MissionManager::execute()
     if (sfr::mission::previous_mode->get_id() != sfr::mission::current_mode->get_id()) {
         sfr::mission::current_mode->set_start_time(millis());
         sfr::mission::current_mode->transition_to();
+#ifdef E2E_TESTING
+        Serial.print("Setting mode to ");
+        Serial.println(sfr::mission::current_mode->get_id());
+#endif
         sfr::mission::mode_history.push_front(sfr::mission::current_mode->get_id());
     }
 

--- a/src/MissionMode.cpp
+++ b/src/MissionMode.cpp
@@ -46,6 +46,7 @@ void DetumbleSpin::dispatch()
     if (sfr::imu::failed_times > sfr::imu::failed_limit) {
         sfr::mission::current_mode = sfr::mission::normal;
     }
+    timed_out(sfr::mission::normal, sfr::acs::detumble_timeout);
 }
 
 void LowPowerDetumbleSpin::transition_to()
@@ -214,6 +215,9 @@ void MandatoryBurns::transition_to()
     sfr::rockblock::sleep_mode = true;
     sfr::acs::off = true;
     sfr::mission::possible_uncovered = true;
+#ifdef E2E_TESTING
+    sfr::rockblock::downlink_period = 30 * constants::time::one_minute;
+#endif
 }
 
 void MandatoryBurns::dispatch()
@@ -305,9 +309,17 @@ void enter_lp(MissionMode *lp_mode)
 {
     float voltage;
 
+#ifndef E2E_TESTING
     if (!sfr::battery::voltage_average->is_valid() || (sfr::battery::voltage_average->get_value(&voltage) && voltage <= sfr::battery::min_battery)) {
         sfr::mission::current_mode = lp_mode;
     }
+#endif
+
+#ifdef E2E_TESTING
+    if (!sfr::battery::voltage_average->is_valid() || (sfr::battery::voltage_value->get_value(&voltage) && voltage <= sfr::battery::min_battery)) {
+        sfr::mission::current_mode = lp_mode;
+    }
+#endif
 }
 
 void check_previous(MissionMode *normal_mode, MissionMode *transmit_mode)

--- a/src/Monitors/BatteryMonitor.cpp
+++ b/src/Monitors/BatteryMonitor.cpp
@@ -8,6 +8,11 @@ BatteryMonitor::BatteryMonitor(unsigned int offset)
 
 void BatteryMonitor::execute()
 {
+    if (!initialized) {
+        sfr::battery::voltage_value->set_valid();
+        sfr::battery::voltage_average->set_valid();
+        initialized = true;
+    }
     float val = analogRead(constants::battery::voltage_value_pin) * constants::battery::voltage_ref / constants::battery::resolution;
     val = val * (constants::battery::r1 + constants::battery::r2) / constants::battery::r2;
 

--- a/src/Monitors/BatteryMonitor.hpp
+++ b/src/Monitors/BatteryMonitor.hpp
@@ -9,6 +9,9 @@ class BatteryMonitor : public TimedControlTask<void>
 public:
     BatteryMonitor(unsigned int offset);
     void execute();
+
+private:
+    bool initialized = false;
 };
 
 #endif

--- a/src/Monitors/CameraReportMonitor.cpp
+++ b/src/Monitors/CameraReportMonitor.cpp
@@ -89,5 +89,8 @@ void CameraReportMonitor::create_camera_report(int fragment_number, uint8_t seri
     for (int i = 0; i < constants::camera::content_length; i++) {
         sfr::rockblock::camera_report.push_back(parsedbuffer[i]);
     }
+#ifdef E2E_TESTNG
+    Serial.println("Camera report ready");
+#endif
     sfr::camera::report_ready = true;
 }

--- a/src/Monitors/TemperatureMonitor.cpp
+++ b/src/Monitors/TemperatureMonitor.cpp
@@ -27,5 +27,8 @@ void TemperatureMonitor::execute()
         sfr::temperature::in_sun = val >= constants::temperature::in_sun_val;
     } else {
         sfr::temperature::in_sun = false;
+#ifdef E2E_TESTING
+        sfr::temperature::in_sun = true;
+#endif
     }
 }

--- a/src/SensorReading.cpp
+++ b/src/SensorReading.cpp
@@ -69,7 +69,7 @@ bool SensorReading::get_value(float *value_location)
         *value_location = average;
         return 1;
     } else {
-        return -1;
+        return 0;
     }
 }
 

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -301,10 +301,10 @@ namespace constants {
         static constexpr unsigned int acs_on_time_offset = acs_max_no_communication_offset + 5;
         static constexpr unsigned int acs_off_offset = acs_on_time_offset + 5;
         static constexpr unsigned int acs_mag_offset = acs_off_offset + 2;
+        static constexpr unsigned int acs_detumble_timeout_offset = acs_mag_offset + 3;
 
-        static constexpr unsigned int battery_acceptable_battery_offset = acs_mag_offset + 3;
+        static constexpr unsigned int battery_acceptable_battery_offset = acs_detumble_timeout_offset + 5;
         static constexpr unsigned int battery_min_battery_offset = battery_acceptable_battery_offset + 5;
-
         static constexpr unsigned int button_pressed_offset = battery_min_battery_offset + 5;
 
         static constexpr unsigned int eeprom_boot_count_offset = button_pressed_offset + 2;

--- a/src/sfr.cpp
+++ b/src/sfr.cpp
@@ -283,10 +283,16 @@ namespace sfr {
         // OP Codes 2500
         SFRField<uint32_t> max_no_communication = SFRField<uint32_t>(0, 0x2500, constants::eeprom::acs_max_no_communication_offset, true);
 
+#ifndef E2E_TESTING
         SFRField<uint32_t> on_time = SFRField<uint32_t>(5 * constants::time::one_minute, 0x2501, constants::eeprom::acs_on_time_offset, true);
+#endif
         SFRField<bool> off = SFRField<bool>(true, 0x2502, constants::eeprom::acs_off_offset, true);
 
         SFRField<uint16_t> mag = SFRField<uint16_t>((uint16_t)simple_acs_type::x, 0x2503, constants::eeprom::acs_mag_offset, true);
+        SFRField<uint32_t> detumble_timeout = SFRField<uint32_t>(30 * constants::time::one_second, 0x2504, constants::eeprom::acs_detumble_timeout_offset, true);
+#ifdef E2E_TESTING
+        SFRField<uint32_t> on_time = SFRField<uint32_t>(5 * constants::time::one_second, 0x2501, constants::eeprom::acs_on_time_offset, true);
+#endif
     } // namespace acs
     namespace battery {
         // OP Codes 2600

--- a/src/sfr.hpp
+++ b/src/sfr.hpp
@@ -306,6 +306,8 @@ namespace sfr {
         extern SFRField<bool> off;
 
         extern SFRField<uint16_t> mag;
+
+        extern SFRField<uint32_t> detumble_timeout;
     } // namespace acs
     namespace battery {
         // OP Codes 2600

--- a/test/test_imu_monitor/test_imu_monitor.cpp
+++ b/test/test_imu_monitor/test_imu_monitor.cpp
@@ -9,6 +9,23 @@ void test_set_valid()
     imu_monitor.execute();
 }
 
+void test_imu_power_cycle()
+{
+    IMUMonitor imu_monitor(0);
+    TEST_ASSERT_FALSE(sfr::imu::powered);
+    imu_monitor.execute();
+    TEST_ASSERT_TRUE(sfr::imu::powered);
+    TEST_ASSERT_FALSE(sfr::imu::turn_on);
+    TEST_ASSERT_TRUE(sfr::imu::mag_x_average->is_valid());
+
+    sfr::imu::turn_off = true;
+    imu_monitor.execute();
+    TEST_ASSERT_FALSE(Pins::getPinState(constants::imu::CSAG));
+    TEST_ASSERT_FALSE(Pins::getPinState(constants::imu::CSM));
+    TEST_ASSERT_FALSE(sfr::imu::powered);
+    TEST_ASSERT_FALSE(sfr::imu::turn_off);
+}
+
 int test_imu_monitor()
 {
     UNITY_BEGIN();


### PR DESCRIPTION
# FS 182 camera report fixes

Fixes [FS-182](https://ssdsalphacubesat.atlassian.net/browse/FS-182?atlOrigin=eyJpIjoiMzQ1MjE5NjE0MjNkNDZmNDkyY2Y4ZjFkNmM0NTRjNjMiLCJwIjoiaiJ9)

### Summary of changes
- Add missing timeout to transition from DetumbleSpin to Normal
- Create a new "E2E_TESTING" flag and add debug statements along with state field changes necessary for e2e test
- Fix return value of get_value() in SensorReading.cpp
- Add buffer initialization logic to BatterMonitor 
- Merge additional IMU monitor unit testing


### Testing
Executed deployment sequence on the EDU via RockblockSimulator to successfully capture and downlink an image in the camera report

### SFR Changes
Add new sfr::acs::detumble_timeout field. Add alternate sfr::acs::on_time setting if E2E_TESTING is declared to enable quick transition between Normal and Transmit modes during downlink testing.


[FS-182]: https://ssdsalphacubesat.atlassian.net/browse/FS-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ