### PR TITLE
Fs 187

### DIFF
--- a/src/Control Tasks/CameraControlTask.cpp
+++ b/src/Control Tasks/CameraControlTask.cpp
@@ -61,20 +61,18 @@ void CameraControlTask::execute()
     }
 
     if (jpglen > 0) {
-        filetocreate = "";
+        String filename = "";
         if (sfr::camera::images_written < 10) {
-            filetocreate += "0";
+            filename += "0";
         }
-        filetocreate += String(sfr::camera::images_written);
-        image_lengths[sfr::camera::images_written] = jpglen;
+        filename += String(sfr::camera::images_written);
 
         if (sfr::camera::fragments_written < 10) {
-            filetocreate += "0";
+            filename += "0";
         }
-        filetocreate += String(sfr::camera::fragments_written) + ".jpg";
-        strcpy(filename, filetocreate.c_str());
+        filename += String(sfr::camera::fragments_written) + ".jpg";
 
-        imgFile = SD.open(filename, FILE_WRITE);
+        File imgFile = SD.open(filename.c_str(), FILE_WRITE);
 
         uint8_t *buffer;
         uint8_t bytesToRead = min(constants::camera::content_length, jpglen);

--- a/src/Control Tasks/CameraControlTask.hpp
+++ b/src/Control Tasks/CameraControlTask.hpp
@@ -13,17 +13,13 @@ class CameraControlTask : public TimedControlTask<void>
 public:
     CameraControlTask(unsigned int offset);
     void execute();
-    Adafruit_VC0706 adaCam;
-    File imgFile;
-    String filetocreate;
 
 private:
     void camera_init();
     void transition_to_normal();
     void transition_to_abnormal_init();
+    Adafruit_VC0706 adaCam;
     uint16_t jpglen = 0;
-    int image_lengths[255];
-    char filename[15];
 };
 
 #endif

--- a/src/Control Tasks/RockblockControlTask.cpp
+++ b/src/Control Tasks/RockblockControlTask.cpp
@@ -536,6 +536,11 @@ RockblockCommand *RockblockControlTask::commandFactory(RawRockblockCommand raw)
         Serial.println("EEPROM Reset Command");
 #endif
         return new EEPROMResetCommand(raw);
+    } else if (op_code == constants::rockblock::opcodes::sfr_field_opcode_camera_fragment_request) {
+#ifdef VERBOSE_RB
+        Serial.println("SFR Camera Fragment Request");
+#endif
+        return new CameraFragmentCommand(raw);
     } else {
 #ifdef VERBOSE_RB
         Serial.print("Unknown Command with opcode: ");

--- a/src/Control Tasks/RockblockControlTask.cpp
+++ b/src/Control Tasks/RockblockControlTask.cpp
@@ -541,6 +541,11 @@ RockblockCommand *RockblockControlTask::commandFactory(RawRockblockCommand raw)
         Serial.println("SFR Camera Fragment Request");
 #endif
         return new CameraFragmentCommand(raw);
+    } else if (op_code == constants::rockblock::opcodes::sfr_field_opcode_imu_fragment_request) {
+#ifdef VERBOSE_RB
+        Serial.println("IMU Fragment Request");
+#endif
+        return new IMUFragmentCommand(raw);
     } else {
 #ifdef VERBOSE_RB
         Serial.print("Unknown Command with opcode: ");

--- a/src/Monitors/CameraReportMonitor.cpp
+++ b/src/Monitors/CameraReportMonitor.cpp
@@ -20,7 +20,7 @@ void CameraReportMonitor::execute()
 #endif
         create_camera_report(fragment_number, current_serial);
         if (fragment_number == sfr::rockblock::camera_max_fragments[current_serial]) {
-            current_serial += 1;
+            current_serial++;
             fragment_number = 0;
             sfr::camera::report_ready = false;
         } else {
@@ -31,7 +31,7 @@ void CameraReportMonitor::execute()
     }
 }
 
-void CameraReportMonitor::create_camera_report(int fragment_number, uint8_t serial_number)
+void CameraReportMonitor::create_camera_report(uint32_t fragment_number, uint8_t serial_number)
 {
     Serial.println("DEBUG: fragment #: " + String(fragment_number));
     Serial.println("DEBUG: serial_number: " + String(serial_number));
@@ -45,14 +45,12 @@ void CameraReportMonitor::create_camera_report(int fragment_number, uint8_t seri
         filename += "0";
     }
     filename += String(fragment_number) + ".jpg";
-    imgFile = SD.open(filename.c_str(), FILE_READ);
+    File imgFile = SD.open(filename.c_str(), FILE_READ);
 
     // parse hex stored as chars into actual hex
-    uint8_t tempbuffer[constants::camera::content_length * 2];
+    uint8_t tempbuffer[constants::camera::content_length];
     uint8_t parsedbuffer[constants::camera::content_length];
-    for (size_t i = 0; i < sizeof(tempbuffer); i++) {
-        tempbuffer[i] = imgFile.read();
-    }
+
     imgFile.read(tempbuffer, constants::camera::content_length);
     int x = 0;
     for (size_t i = 0; i < sizeof(tempbuffer); i++) {

--- a/src/Monitors/CameraReportMonitor.hpp
+++ b/src/Monitors/CameraReportMonitor.hpp
@@ -14,9 +14,8 @@ public:
     void execute();
 
 private:
-    void create_camera_report(int fragment_number, uint8_t serial_number);
+    void create_camera_report(uint32_t fragment_number, uint8_t serial_number);
     uint32_t fragment_number = 0;
-    uint32_t current_serial = 0;
-    File imgFile;
+    uint8_t current_serial = 0;
 };
 #endif

--- a/src/Monitors/IMUDownlinkReportMonitor.cpp
+++ b/src/Monitors/IMUDownlinkReportMonitor.cpp
@@ -14,10 +14,13 @@ void IMUDownlinkReportMonitor::execute()
         create_imu_downlink_report(fragment_number);
         fragment_number++;
     }
+
+    if (sfr::imu::fragment_requested && !sfr::imu::report_ready) {
+        create_imu_downlink_report_from_SD(sfr::imu::fragment_number_requested);
+    }
 }
 
-// Creates IMU report given a fragment number
-void IMUDownlinkReportMonitor::create_imu_downlink_report(int fragment_number)
+void IMUDownlinkReportMonitor::create_imu_downlink_report(uint8_t fragment_number)
 {
     // Set report is not ready if imu_dlink is empty and all fragments have been downlinked
     if (sfr::imu::imu_dlink.size() == 0 && sfr::rockblock::imu_report.size() == 0) {
@@ -25,27 +28,107 @@ void IMUDownlinkReportMonitor::create_imu_downlink_report(int fragment_number)
         return;
     }
 
-    // Push report ID
+    // Set up fragment save to SD card
+    String filename = "imu_frag_" + String(fragment_number) + ".txt";
+    File txtFile = SD.open(filename.c_str(), FILE_WRITE);
+
+    // pushed imu report id
     sfr::rockblock::imu_report.push_back(24);
+    txtFile.print(24, HEX);
 
     // Push fragment number to the report
     sfr::rockblock::imu_report.push_back(fragment_number);
+    txtFile.print(24, HEX);
 
     // Add values to the report and delete from buffer.
     for (int i = 0; i < pop_size; i++) {
-        sfr::rockblock::imu_report.push_back(sfr::imu::imu_dlink.back());
+        uint8_t data = sfr::imu::imu_dlink.back();
+        sfr::rockblock::imu_report.push_back(data);
+        txtFile.print(data, HEX);
         sfr::imu::imu_dlink.pop_back();
     }
     // Push end flag at the end of the report
     sfr::rockblock::imu_report.push_back(constants::imu_downlink::imu_report_endflag1);
     sfr::rockblock::imu_report.push_back(constants::imu_downlink::imu_report_endflag2);
 
-    // Set report is ready for the next downlink
+    // place the endflag at the end of the message
+    if (fragment_number >= (int)(constants::imu_downlink::downlink_FIFO_byte_length / pop_size - 1)) {
+        sfr::rockblock::imu_report.push_back(constants::imu_downlink::imu_report_endflag1);
+        sfr::rockblock::imu_report.push_back(constants::imu_downlink::imu_report_endflag2);
+        txtFile.print(constants::imu_downlink::imu_report_endflag1, HEX);
+        txtFile.print(constants::imu_downlink::imu_report_endflag2, HEX);
+    }
+
+    txtFile.close();
+    // write_imu_report_to_SD(fragment_number);
+    // for the next downlink cycle
     sfr::imu::report_ready = true;
 }
 
-void IMUDownlinkReportMonitor::write_imu_report_to_SD(int fragment_number)
+void IMUDownlinkReportMonitor::create_imu_downlink_report_from_SD(uint8_t fragment_number)
+{
+    // open image file and read it for specified image/fragment
+    String filename = "imu_frag_" + String(fragment_number) + ".txt";
+    File txtFile = SD.open(filename.c_str(), FILE_READ);
+
+    // parse hex stored as chars into actual hex
+    uint8_t tempbuffer[constants::imu::max_gyro_imu_report_size];
+    uint8_t parsedbuffer[constants::camera::content_length];
+    for (size_t i = 0; i < sizeof(tempbuffer); i++) {
+        tempbuffer[i] = txtFile.read();
+    }
+
+    txtFile.read(tempbuffer, constants::camera::content_length);
+    int x = 0;
+    for (size_t i = 0; i < sizeof(tempbuffer); i++) {
+        int byte_0;
+        int byte_1;
+        if (tempbuffer[i] <= 90 && tempbuffer[i] >= 65) {
+            byte_0 = tempbuffer[i] - 55;
+        } else {
+            byte_0 = tempbuffer[i] - 48;
+        }
+        if (tempbuffer[i + 1] <= 90 && tempbuffer[i + 1] >= 65) {
+            byte_1 = tempbuffer[i + 1] - 55;
+        } else {
+            byte_1 = tempbuffer[i + 1] - 48;
+        }
+        parsedbuffer[x] = byte_1 + (byte_0 * 16);
+        x++;
+        i++;
+    }
+    imgFile.close();
+
+    sfr::rockblock::camera_report.push_back(42);
+    // get each byte of serial number and add to camera report
+    sfr::rockblock::camera_report.push_back(serial_number);
+
+    // get each byte of fragment number
+    std::vector<unsigned char> fragment(constants::camera::bytes_allocated_fragment);
+    for (size_t i = 0; i < constants::camera::bytes_allocated_fragment; i++) {
+        fragment[3 - i] = (fragment_number >> (i * 8));
+        sfr::rockblock::camera_report.push_back(fragment[i]);
+    }
+
+    // add actual image content to camera report
+    for (int i = 0; i < constants::camera::content_length; i++) {
+        sfr::rockblock::camera_report.push_back(parsedbuffer[i]);
+    }
+#ifdef E2E_TESTNG
+    Serial.println("Camera report ready");
+#endif
+    sfr::camera::report_ready = true;
+}
+
+// SD write is already done as report is being made, but can be factored out in this function if that is safer
+void IMUDownlinkReportMonitor::write_imu_report_to_SD(uint8_t fragment_number)
 {
     String filename = "imu_frag_" + String(fragment_number) + ".txt";
-    imgFile = SD.open(filename.c_str(), FILE_WRITE);
+    File txtFile = SD.open(filename.c_str(), FILE_WRITE);
+
+    for (uint8_t &data : sfr::rockblock::imu_report) {
+        txtFile.print(data, HEX);
+    }
+
+    txtFile.close();
 }

--- a/src/Monitors/IMUDownlinkReportMonitor.cpp
+++ b/src/Monitors/IMUDownlinkReportMonitor.cpp
@@ -43,3 +43,9 @@ void IMUDownlinkReportMonitor::create_imu_downlink_report(int fragment_number)
     // Set report is ready for the next downlink
     sfr::imu::report_ready = true;
 }
+
+void IMUDownlinkReportMonitor::write_imu_report_to_SD(int fragment_number)
+{
+    String filename = "imu_frag_" + String(fragment_number) + ".txt";
+    imgFile = SD.open(filename.c_str(), FILE_WRITE);
+}

--- a/src/Monitors/IMUDownlinkReportMonitor.cpp
+++ b/src/Monitors/IMUDownlinkReportMonitor.cpp
@@ -29,7 +29,7 @@ void IMUDownlinkReportMonitor::create_imu_downlink_report(uint8_t fragment_numbe
         return;
     }
 
-    // pushed imu report id
+    // Push imu report id
     sfr::rockblock::imu_report.push_back(24);
 
     // Push fragment number to the report
@@ -45,7 +45,7 @@ void IMUDownlinkReportMonitor::create_imu_downlink_report(uint8_t fragment_numbe
     String filename = "imu_frag_" + String(fragment_number) + ".txt";
     File txtFile = SD.open(filename.c_str(), FILE_WRITE);
 
-    // add actual gyro content to imu report
+    // Add actual gyro content to imu report
     for (int i = 0; i < pop_size; i++) {
         uint8_t data = sfr::imu::imu_dlink.back();
         sfr::rockblock::imu_report.push_back(data);
@@ -58,23 +58,23 @@ void IMUDownlinkReportMonitor::create_imu_downlink_report(uint8_t fragment_numbe
 
     txtFile.close();
 
-    // place the endflag at the end of the message
+    // Place the endflag at the end of the message
     if (fragment_number >= (int)(constants::imu_downlink::downlink_FIFO_byte_length / pop_size - 1)) {
         sfr::rockblock::imu_report.push_back(constants::imu_downlink::imu_report_endflag1);
         sfr::rockblock::imu_report.push_back(constants::imu_downlink::imu_report_endflag2);
     }
 
-    // for the next downlink cycle
+    // For the next downlink cycle
     sfr::imu::report_ready = true;
 }
 
 void IMUDownlinkReportMonitor::create_imu_downlink_report_from_SD(uint8_t fragment_number)
 {
-    // open image file and read it for specified image/fragment
+    // Open image file and read it for specified image/fragment
     String filename = "imu_frag_" + String(fragment_number) + ".txt";
     File txtFile = SD.open(filename.c_str(), FILE_READ);
 
-    // parse hex stored as chars into actual hex
+    // Parse hex stored as chars into actual hex
     uint8_t tempbuffer[constants::imu::max_gyro_imu_report_size];
     uint8_t parsedbuffer[constants::imu::max_gyro_imu_report_size];
 
@@ -104,7 +104,7 @@ void IMUDownlinkReportMonitor::create_imu_downlink_report_from_SD(uint8_t fragme
     sfr::rockblock::imu_report.push_back(24);
     sfr::rockblock::imu_report.push_back(fragment_number);
 
-    // add fragment data to imu report
+    // Add fragment data to imu report
     for (int i = 0; i < constants::camera::content_length; i++) {
         sfr::rockblock::imu_report.push_back(parsedbuffer[i]);
     }

--- a/src/Monitors/IMUDownlinkReportMonitor.cpp
+++ b/src/Monitors/IMUDownlinkReportMonitor.cpp
@@ -63,7 +63,6 @@ void IMUDownlinkReportMonitor::create_imu_downlink_report(uint8_t fragment_numbe
         sfr::rockblock::imu_report.push_back(constants::imu_downlink::imu_report_endflag2);
     }
 
-    // write_imu_report_to_SD(fragment_number);
     // for the next downlink cycle
     sfr::imu::report_ready = true;
 }
@@ -97,17 +96,4 @@ void IMUDownlinkReportMonitor::create_imu_downlink_report_from_SD(uint8_t fragme
     Serial.println("IMU report ready");
 #endif
     sfr::imu::report_ready = true;
-}
-
-// SD write is already done as report is being made, but can be factored out in this function if that is safer
-void IMUDownlinkReportMonitor::write_imu_report_to_SD(uint8_t fragment_number)
-{
-    String filename = "imu_frag_" + String(fragment_number) + ".txt";
-    File txtFile = SD.open(filename.c_str(), FILE_WRITE);
-
-    for (uint8_t &data : sfr::rockblock::imu_report) {
-        txtFile.print(data, HEX);
-    }
-
-    txtFile.close();
 }

--- a/src/Monitors/IMUDownlinkReportMonitor.cpp
+++ b/src/Monitors/IMUDownlinkReportMonitor.cpp
@@ -52,6 +52,7 @@ void IMUDownlinkReportMonitor::create_imu_downlink_report(uint8_t fragment_numbe
         txtFile.print(data, HEX);
         sfr::imu::imu_dlink.pop_back();
     }
+
     // Push end flag at the end of the report
     sfr::rockblock::imu_report.push_back(constants::imu_downlink::imu_report_endflag1);
     sfr::rockblock::imu_report.push_back(constants::imu_downlink::imu_report_endflag2);
@@ -59,10 +60,8 @@ void IMUDownlinkReportMonitor::create_imu_downlink_report(uint8_t fragment_numbe
     txtFile.close();
 
     // Place the endflag at the end of the message
-    if (fragment_number >= (int)(constants::imu_downlink::downlink_FIFO_byte_length / pop_size - 1)) {
-        sfr::rockblock::imu_report.push_back(constants::imu_downlink::imu_report_endflag1);
-        sfr::rockblock::imu_report.push_back(constants::imu_downlink::imu_report_endflag2);
-    }
+    sfr::rockblock::imu_report.push_back(constants::imu_downlink::imu_report_endflag1);
+    sfr::rockblock::imu_report.push_back(constants::imu_downlink::imu_report_endflag2);
 
     // For the next downlink cycle
     sfr::imu::report_ready = true;

--- a/src/Monitors/IMUDownlinkReportMonitor.hpp
+++ b/src/Monitors/IMUDownlinkReportMonitor.hpp
@@ -16,7 +16,6 @@ public:
 private:
     void create_imu_downlink_report(uint8_t fragment_number);
     void create_imu_downlink_report_from_SD(uint8_t fragment_number);
-    void write_imu_report_to_SD(uint8_t fragment_number);
     bool start_timing_deployed = false;
     uint8_t current_sample = 0;
     uint8_t fragment_number = 0;

--- a/src/Monitors/IMUDownlinkReportMonitor.hpp
+++ b/src/Monitors/IMUDownlinkReportMonitor.hpp
@@ -3,6 +3,7 @@
 
 #include "Control Tasks/TimedControlTask.hpp"
 #include "sfr.hpp"
+#include <SD.h>
 #include <cassert>
 #include <vector>
 
@@ -14,6 +15,7 @@ public:
 
 private:
     void create_imu_downlink_report(int fragment_number);
+    void write_imu_report_to_SD(int fragment_number);
     bool start_timing_deployed = false;
     uint8_t current_sample = 0;
     uint8_t fragment_number = 0;
@@ -21,6 +23,7 @@ private:
     bool report_downlinked = true;
     // Sets the amount of values that go into the report.
     int pop_size = min(constants::imu::max_gyro_imu_report_size, sfr::imu::imu_dlink.size());
+    File imgFile;
 };
 
 #endif

--- a/src/Monitors/IMUDownlinkReportMonitor.hpp
+++ b/src/Monitors/IMUDownlinkReportMonitor.hpp
@@ -14,16 +14,14 @@ public:
     void execute();
 
 private:
-    void create_imu_downlink_report(int fragment_number);
-    void write_imu_report_to_SD(int fragment_number);
+    void create_imu_downlink_report(uint8_t fragment_number);
+    void create_imu_downlink_report_from_SD(uint8_t fragment_number);
+    void write_imu_report_to_SD(uint8_t fragment_number);
     bool start_timing_deployed = false;
     uint8_t current_sample = 0;
     uint8_t fragment_number = 0;
     bool report_ready = false;
     bool report_downlinked = true;
-    // Sets the amount of values that go into the report.
-    int pop_size = min(constants::imu::max_gyro_imu_report_size, sfr::imu::imu_dlink.size());
-    File imgFile;
 };
 
 #endif

--- a/src/RockblockCommand.cpp
+++ b/src/RockblockCommand.cpp
@@ -1,0 +1,29 @@
+#include "RockBlockCommand.hpp"
+#include "sfr.hpp"
+
+void CameraFragmentCommand::execute()
+{
+    sfr::camera::fragment_requested = true;
+    sfr::camera::serial_requested = f_arg_1;
+    sfr::camera::fragment_number_requested = f_arg_2;
+}
+
+bool CameraFragmentCommand::isValid()
+{
+    for (int mission_mode : sfr::mission::mode_history) {
+        if (mission_mode == 22) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void IMUFragmentCommand::execute()
+{
+    // TODO: implement
+}
+
+bool IMUFragmentCommand::isValid()
+{
+    return true;
+}

--- a/src/RockblockCommand.cpp
+++ b/src/RockblockCommand.cpp
@@ -20,10 +20,16 @@ bool CameraFragmentCommand::isValid()
 
 void IMUFragmentCommand::execute()
 {
-    // TODO: implement
+    sfr::imu::fragment_requested = true;
+    sfr::imu::fragment_number_requested = f_arg_1;
 }
 
 bool IMUFragmentCommand::isValid()
 {
-    return true;
+    for (int mission_mode : sfr::mission::mode_history) {
+        if (mission_mode == 22) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/src/RockblockCommand.hpp
+++ b/src/RockblockCommand.hpp
@@ -139,6 +139,27 @@ public:
     }
 };
 
+class CameraFragmentCommand : public RockblockCommand
+{
+public:
+    CameraFragmentCommand(RawRockblockCommand raw) : RockblockCommand{raw} {};
+
+    void execute();
+    bool isValid();
+};
+
+class IMUFragmentCommand : public RockblockCommand
+{
+public:
+    IMUFragmentCommand(RawRockblockCommand raw) : RockblockCommand{raw} {};
+
+    void execute();
+    bool isValid();
+
+private:
+    SFRInterface *field;
+};
+
 class UnknownCommand : public RockblockCommand
 {
 public:

--- a/src/RockblockSimulator.cpp
+++ b/src/RockblockSimulator.cpp
@@ -26,8 +26,8 @@ RockblockSimulator::RockblockSimulator()
     // insert("5555111111111111111100FA");
 
     // command to downlink second image fragment of first image
-    // opcode 6010
-    insert("601000000000000000100FA");
+    // opcode 8888
+    insert("888800000000000000100FA");
 }
 
 void RockblockSimulator::begin(uint32_t baud)

--- a/src/RockblockSimulator.cpp
+++ b/src/RockblockSimulator.cpp
@@ -24,6 +24,10 @@ RockblockSimulator::RockblockSimulator()
     // insert("3333111111111111111100FA");
     // insert("4444111111111111111100FA");
     // insert("5555111111111111111100FA");
+
+    // command to downlink second image fragment of first image
+    // opcode 6010
+    insert("0x6010000000010000000200FA");
 }
 
 void RockblockSimulator::begin(uint32_t baud)

--- a/src/RockblockSimulator.cpp
+++ b/src/RockblockSimulator.cpp
@@ -27,7 +27,7 @@ RockblockSimulator::RockblockSimulator()
 
     // command to downlink second image fragment of first image
     // opcode 6010
-    insert("0x6010000000010000000200FA");
+    insert("601000000000000000100FA");
 }
 
 void RockblockSimulator::begin(uint32_t baud)

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -67,6 +67,9 @@ namespace constants {
             // EEPROM Reset Command
             constexpr uint16_t eeprom_reset_opcode = 0x7777;
 
+            // Fragment Request Commands
+            constexpr uint16_t sfr_field_opcode_camera_fragment_request = 0x8888;
+            constexpr uint16_t sfr_field_opcode_imu_fragment_request = 0x9999;
         } // namespace opcodes
     }     // namespace rockblock
     namespace temperature {

--- a/src/sfr.cpp
+++ b/src/sfr.cpp
@@ -191,13 +191,15 @@ namespace sfr {
         SFRField<bool> powered = SFRField<bool>(false, 0x2203);
         SFRField<bool> report_written = SFRField<bool>(false, 0x2204);
         SFRField<bool> report_ready = SFRField<bool>(false, 0x2205);
-        SFRField<uint16_t> mode = SFRField<uint16_t>((uint16_t)sensor_mode_type::init, 0x2206);
-        SFRField<uint16_t> init_mode = SFRField<uint16_t>((uint16_t)sensor_init_mode_type::awaiting, 0x2207);
-        SFRField<uint16_t> failed_times = SFRField<uint16_t>(0, 0x2208);
-        SFRField<uint16_t> failed_limit = SFRField<uint16_t>(5, 0x2209);
-        SFRField<uint16_t> imu_boot_collection_start_time = SFRField<uint16_t>(0, 0x2210);
-        SFRField<uint16_t> door_open_start_time = SFRField<uint16_t>(0, 0x2211);
-        SFRField<uint32_t> max_fragments = SFRField<uint32_t>(256, 0x2212);
+        SFRField<bool> fragment_requested = SFRField<bool>(false, 0x2206);
+        SFRField<uint8_t> fragment_number_requested = SFRField<uint8_t>(0, 0x2207);
+        SFRField<uint16_t> mode = SFRField<uint16_t>((uint16_t)sensor_mode_type::init, 0x2208);
+        SFRField<uint16_t> init_mode = SFRField<uint16_t>((uint16_t)sensor_init_mode_type::awaiting, 0x2209);
+        SFRField<uint16_t> failed_times = SFRField<uint16_t>(0, 0x2210);
+        SFRField<uint16_t> failed_limit = SFRField<uint16_t>(5, 0x2211);
+        SFRField<uint16_t> imu_boot_collection_start_time = SFRField<uint16_t>(0, 0x2212);
+        SFRField<uint16_t> door_open_start_time = SFRField<uint16_t>(0, 0x2213);
+        SFRField<uint32_t> max_fragments = SFRField<uint32_t>(256, 0x2214);
 
         SensorReading *mag_x_value = new SensorReading(fault_groups::imu_faults::mag_x_value, 1, constants::imu::min_mag, constants::imu::max_mag);
         SensorReading *mag_y_value = new SensorReading(fault_groups::imu_faults::mag_y_value, 1, constants::imu::min_mag, constants::imu::max_mag);

--- a/src/sfr.hpp
+++ b/src/sfr.hpp
@@ -206,6 +206,8 @@ namespace sfr {
         extern SFRField<bool> powered;
         extern SFRField<bool> report_written;
         extern SFRField<bool> report_ready;
+        extern SFRField<bool> fragment_requested;
+        extern SFRField<uint8_t> fragment_number_requested;
         extern SFRField<uint16_t> mode;
         extern SFRField<uint16_t> init_mode;
         extern SFRField<uint16_t> failed_times;


### PR DESCRIPTION
Implementation of camera fragment downlinking (creation of command to request specific camera fragments). Created this draft PR for documentation purposes at end of SP23. 

Currently, the downlink command is being accepted, and the desired serial and fragment numbers are being acknowledged. However, the image data downlinked is not correct (repeating BFBFBF... after the camera report flag and serial/fragment #s). The main todo is to figure out why this is, and possibly implement the same logic for the imu report, currently a method stub in RockblockCommand.cpp