### PR TITLE
Re-add EEPROMRestore

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,8 +13,7 @@ void setup()
     Serial.begin(9600);
     delay(5000);
     Pins::setInitialPinStates();
-    // TODO: Uncomment when EEPROMRestore is fixed (FS-186)
-    // EEPROMRestore::execute();
+    EEPROMRestore::execute();
 }
 
 void loop()


### PR DESCRIPTION
([FS-186](https://ssdsalphacubesat.atlassian.net/browse/FS-186?atlOrigin=eyJpIjoiYmZjODAzM2FhMTY2NGFmZjlhZDIxZjk4ZmNhZmE1ZjIiLCJwIjoiaiJ9) was a False Alarm - run './zero_out_eeprom.cpp' script Eric made to fix issue on a teensy by resetting eeprom values to 0)

[FS-186]: https://ssdsalphacubesat.atlassian.net/browse/FS-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ