### PR TITLE
EEPROM cleanup

### DIFF
--- a/src/Control Tasks/EEPROMControlTask.cpp
+++ b/src/Control Tasks/EEPROMControlTask.cpp
@@ -36,8 +36,8 @@ void EEPROMControlTask::execute()
 
 void EEPROMControlTask::save_boot_time()
 {
-    EEPROM.put(constants::eeprom::boot_time_loc1, sfr::eeprom::time_alive);
-    EEPROM.put(constants::eeprom::boot_time_loc2, sfr::eeprom::time_alive);
+    EEPROM.put(constants::eeprom::boot_time_loc1, sfr::eeprom::time_alive.get());
+    EEPROM.put(constants::eeprom::boot_time_loc2, sfr::eeprom::time_alive.get());
 }
 
 void EEPROMControlTask::save_dynamic_data()
@@ -45,16 +45,16 @@ void EEPROMControlTask::save_dynamic_data()
     if (sfr::eeprom::dynamic_data_age == 95000) {
         // If write age reached, shift and save the dynamic data address
         sfr::eeprom::dynamic_data_addr += constants::eeprom::dynamic_data_full_offset;
-        EEPROM.put(constants::eeprom::dynamic_data_addr_loc1, sfr::eeprom::dynamic_data_addr);
-        EEPROM.put(constants::eeprom::dynamic_data_addr_loc2, sfr::eeprom::dynamic_data_addr);
+        EEPROM.put(constants::eeprom::dynamic_data_addr_loc1, sfr::eeprom::dynamic_data_addr.get());
+        EEPROM.put(constants::eeprom::dynamic_data_addr_loc2, sfr::eeprom::dynamic_data_addr.get());
         sfr::eeprom::dynamic_data_age = 0;
     }
 
     if (sfr::eeprom::dynamic_data_addr + constants::eeprom::dynamic_data_full_offset > constants::eeprom::sfr_data_start) {
         // There is enough memory for another cycle of dynamic data
         sfr::eeprom::dynamic_data_age++;
-        EEPROM.put(sfr::eeprom::dynamic_data_addr, sfr::eeprom::time_alive);
-        EEPROM.put(sfr::eeprom::dynamic_data_addr + 4, sfr::eeprom::dynamic_data_age);
+        EEPROM.put(sfr::eeprom::dynamic_data_addr, sfr::eeprom::time_alive.get());
+        EEPROM.put(sfr::eeprom::dynamic_data_addr + 4, sfr::eeprom::dynamic_data_age.get());
     }
 }
 
@@ -63,8 +63,8 @@ void EEPROMControlTask::save_sfr_data()
     if (sfr::eeprom::sfr_data_age == 95000) {
         // If write age reached, shift and save the SFR data address
         sfr::eeprom::sfr_data_age += constants::eeprom::sfr_data_full_offset;
-        EEPROM.put(constants::eeprom::sfr_data_addr_loc1, sfr::eeprom::sfr_data_addr);
-        EEPROM.put(constants::eeprom::sfr_data_addr_loc2, sfr::eeprom::sfr_data_addr);
+        EEPROM.put(constants::eeprom::sfr_data_addr_loc1, sfr::eeprom::sfr_data_addr.get());
+        EEPROM.put(constants::eeprom::sfr_data_addr_loc2, sfr::eeprom::sfr_data_addr.get());
         sfr::eeprom::sfr_data_age = 0;
     }
 
@@ -73,7 +73,7 @@ void EEPROMControlTask::save_sfr_data()
 
         // Update and write SFR data age
         sfr::eeprom::sfr_data_age++;
-        EEPROM.put(sfr::eeprom::sfr_data_addr, sfr::eeprom::sfr_data_age);
+        EEPROM.put(sfr::eeprom::sfr_data_addr, sfr::eeprom::sfr_data_age.get());
 
         // Save each SFR field's restore boolean and value as a uint32_t
         uint16_t sfr_write_address = sfr::eeprom::sfr_data_addr + 4;
@@ -84,7 +84,7 @@ void EEPROMControlTask::save_sfr_data()
         }
 
         // Write SFR data age again. EEPROM restore will check that these ages match to determine if the last SFR save was completed.
-        EEPROM.put(sfr_write_address, sfr::eeprom::sfr_data_age);
+        EEPROM.put(sfr_write_address, sfr::eeprom::sfr_data_age.get());
     }
 }
 

--- a/src/Control Tasks/EEPROMControlTask.cpp
+++ b/src/Control Tasks/EEPROMControlTask.cpp
@@ -36,8 +36,8 @@ void EEPROMControlTask::execute()
 
 void EEPROMControlTask::save_boot_time()
 {
-    EEPROM.put(constants::eeprom::boot_time_loc1, sfr::eeprom::time_alive);
-    EEPROM.put(constants::eeprom::boot_time_loc2, sfr::eeprom::time_alive);
+    EEPROM.put(constants::eeprom::boot_time_loc1, sfr::eeprom::time_alive.getFieldValue());
+    EEPROM.put(constants::eeprom::boot_time_loc2, sfr::eeprom::time_alive.getFieldValue());
 }
 
 void EEPROMControlTask::save_dynamic_data()
@@ -45,16 +45,16 @@ void EEPROMControlTask::save_dynamic_data()
     if (sfr::eeprom::dynamic_data_age == 95000) {
         // If write age reached, shift and save the dynamic data address
         sfr::eeprom::dynamic_data_addr += constants::eeprom::dynamic_data_full_offset;
-        EEPROM.put(constants::eeprom::dynamic_data_addr_loc1, sfr::eeprom::dynamic_data_addr);
-        EEPROM.put(constants::eeprom::dynamic_data_addr_loc2, sfr::eeprom::dynamic_data_addr);
+        EEPROM.put(constants::eeprom::dynamic_data_addr_loc1, sfr::eeprom::dynamic_data_addr.getFieldValue());
+        EEPROM.put(constants::eeprom::dynamic_data_addr_loc2, sfr::eeprom::dynamic_data_addr.getFieldValue());
         sfr::eeprom::dynamic_data_age = 0;
     }
 
     if (sfr::eeprom::dynamic_data_addr + constants::eeprom::dynamic_data_full_offset > constants::eeprom::sfr_data_start) {
         // There is enough memory for another cycle of dynamic data
         sfr::eeprom::dynamic_data_age++;
-        EEPROM.put(sfr::eeprom::dynamic_data_addr, sfr::eeprom::time_alive);
-        EEPROM.put(sfr::eeprom::dynamic_data_addr + 4, sfr::eeprom::dynamic_data_age);
+        EEPROM.put(sfr::eeprom::dynamic_data_addr, sfr::eeprom::time_alive.getFieldValue());
+        EEPROM.put(sfr::eeprom::dynamic_data_addr + 4, sfr::eeprom::dynamic_data_age.getFieldValue());
     }
 }
 
@@ -63,8 +63,8 @@ void EEPROMControlTask::save_sfr_data()
     if (sfr::eeprom::sfr_data_age == 95000) {
         // If write age reached, shift and save the SFR data address
         sfr::eeprom::sfr_data_age += constants::eeprom::sfr_data_full_offset;
-        EEPROM.put(constants::eeprom::sfr_data_addr_loc1, sfr::eeprom::sfr_data_addr);
-        EEPROM.put(constants::eeprom::sfr_data_addr_loc2, sfr::eeprom::sfr_data_addr);
+        EEPROM.put(constants::eeprom::sfr_data_addr_loc1, sfr::eeprom::sfr_data_addr.getFieldValue());
+        EEPROM.put(constants::eeprom::sfr_data_addr_loc2, sfr::eeprom::sfr_data_addr.getFieldValue());
         sfr::eeprom::sfr_data_age = 0;
     }
 
@@ -73,7 +73,7 @@ void EEPROMControlTask::save_sfr_data()
 
         // Update and write SFR data age
         sfr::eeprom::sfr_data_age++;
-        EEPROM.put(sfr::eeprom::sfr_data_addr, sfr::eeprom::sfr_data_age);
+        EEPROM.put(sfr::eeprom::sfr_data_addr, sfr::eeprom::sfr_data_age.getFieldValue());
 
         // Save SFR fields
         uint16_t sfr_write_address = sfr::eeprom::sfr_data_addr + 4;
@@ -84,7 +84,7 @@ void EEPROMControlTask::save_sfr_data()
         }
 
         // Write SFR data age again. EEPROM restore will check that these ages match to determine if the last SFR save was completed.
-        EEPROM.put(sfr_write_address, sfr::eeprom::sfr_data_age);
+        EEPROM.put(sfr_write_address, sfr::eeprom::sfr_data_age.getFieldValue());
     }
 }
 

--- a/src/Control Tasks/EEPROMControlTask.cpp
+++ b/src/Control Tasks/EEPROMControlTask.cpp
@@ -9,16 +9,16 @@ void EEPROMControlTask::execute()
 {
     sfr::eeprom::time_alive = millis();
 
-    if (sfr::eeprom::time_alive - sfr::eeprom::last_fast_save_time > constants::eeprom::fast_write_interval && sfr::eeprom::boot_mode) {
+    if (sfr::eeprom::time_alive - last_boot_counter_save_time > constants::eeprom::fast_write_interval && sfr::eeprom::boot_mode) {
         // Adequate time has passed for a new write, and EEPROM is counting time in boot
         EEPROMControlTask::save_boot_time();
-        sfr::eeprom::last_fast_save_time = sfr::eeprom::time_alive;
+        last_boot_counter_save_time = sfr::eeprom::time_alive;
     }
 
-    if (sfr::eeprom::time_alive - sfr::eeprom::last_fast_save_time > constants::eeprom::fast_write_interval && !sfr::eeprom::boot_mode && !sfr::eeprom::error_mode) {
+    if (sfr::eeprom::time_alive - last_dynamic_save_time > constants::eeprom::fast_write_interval && !sfr::eeprom::boot_mode && !sfr::eeprom::error_mode) {
         // Adequate time has passed for a new write, and EEPROM has finished counting time in boot, and EEPROM is valid
         EEPROMControlTask::save_dynamic_data();
-        sfr::eeprom::last_fast_save_time = sfr::eeprom::time_alive;
+        last_dynamic_save_time = sfr::eeprom::time_alive;
     }
 
     unsigned int write_interval = constants::eeprom::slow_write_interval;
@@ -27,17 +27,17 @@ void EEPROMControlTask::execute()
         write_interval = constants::eeprom::fast_write_interval;
     }
 
-    if (sfr::eeprom::time_alive - sfr::eeprom::last_sfr_save_time > write_interval && !sfr::eeprom::boot_mode && !sfr::eeprom::error_mode) {
+    if (sfr::eeprom::time_alive - last_sfr_save_time > write_interval && !sfr::eeprom::boot_mode && !sfr::eeprom::error_mode) {
         // Adequate time has passed for a new write, and EEPROM has finished counting time in boot, and EEPROM is valid
         EEPROMControlTask::save_sfr_data();
-        sfr::eeprom::last_sfr_save_time = sfr::eeprom::time_alive;
+        last_sfr_save_time = sfr::eeprom::time_alive;
     }
 }
 
 void EEPROMControlTask::save_boot_time()
 {
-    EEPROM.put(constants::eeprom::boot_time_loc1, sfr::eeprom::time_alive.getFieldValue());
-    EEPROM.put(constants::eeprom::boot_time_loc2, sfr::eeprom::time_alive.getFieldValue());
+    EEPROM.put(constants::eeprom::boot_time_loc1, sfr::eeprom::time_alive);
+    EEPROM.put(constants::eeprom::boot_time_loc2, sfr::eeprom::time_alive);
 }
 
 void EEPROMControlTask::save_dynamic_data()
@@ -45,16 +45,16 @@ void EEPROMControlTask::save_dynamic_data()
     if (sfr::eeprom::dynamic_data_age == 95000) {
         // If write age reached, shift and save the dynamic data address
         sfr::eeprom::dynamic_data_addr += constants::eeprom::dynamic_data_full_offset;
-        EEPROM.put(constants::eeprom::dynamic_data_addr_loc1, sfr::eeprom::dynamic_data_addr.getFieldValue());
-        EEPROM.put(constants::eeprom::dynamic_data_addr_loc2, sfr::eeprom::dynamic_data_addr.getFieldValue());
+        EEPROM.put(constants::eeprom::dynamic_data_addr_loc1, sfr::eeprom::dynamic_data_addr);
+        EEPROM.put(constants::eeprom::dynamic_data_addr_loc2, sfr::eeprom::dynamic_data_addr);
         sfr::eeprom::dynamic_data_age = 0;
     }
 
     if (sfr::eeprom::dynamic_data_addr + constants::eeprom::dynamic_data_full_offset > constants::eeprom::sfr_data_start) {
         // There is enough memory for another cycle of dynamic data
         sfr::eeprom::dynamic_data_age++;
-        EEPROM.put(sfr::eeprom::dynamic_data_addr, sfr::eeprom::time_alive.getFieldValue());
-        EEPROM.put(sfr::eeprom::dynamic_data_addr + 4, sfr::eeprom::dynamic_data_age.getFieldValue());
+        EEPROM.put(sfr::eeprom::dynamic_data_addr, sfr::eeprom::time_alive);
+        EEPROM.put(sfr::eeprom::dynamic_data_addr + 4, sfr::eeprom::dynamic_data_age);
     }
 }
 
@@ -63,8 +63,8 @@ void EEPROMControlTask::save_sfr_data()
     if (sfr::eeprom::sfr_data_age == 95000) {
         // If write age reached, shift and save the SFR data address
         sfr::eeprom::sfr_data_age += constants::eeprom::sfr_data_full_offset;
-        EEPROM.put(constants::eeprom::sfr_data_addr_loc1, sfr::eeprom::sfr_data_addr.getFieldValue());
-        EEPROM.put(constants::eeprom::sfr_data_addr_loc2, sfr::eeprom::sfr_data_addr.getFieldValue());
+        EEPROM.put(constants::eeprom::sfr_data_addr_loc1, sfr::eeprom::sfr_data_addr);
+        EEPROM.put(constants::eeprom::sfr_data_addr_loc2, sfr::eeprom::sfr_data_addr);
         sfr::eeprom::sfr_data_age = 0;
     }
 
@@ -73,9 +73,9 @@ void EEPROMControlTask::save_sfr_data()
 
         // Update and write SFR data age
         sfr::eeprom::sfr_data_age++;
-        EEPROM.put(sfr::eeprom::sfr_data_addr, sfr::eeprom::sfr_data_age.getFieldValue());
+        EEPROM.put(sfr::eeprom::sfr_data_addr, sfr::eeprom::sfr_data_age);
 
-        // Save SFR fields
+        // Save each SFR field's restore boolean and value as a uint32_t
         uint16_t sfr_write_address = sfr::eeprom::sfr_data_addr + 4;
         for (const auto &pair : SFRInterface::opcode_lookup) {
             EEPROM.put(sfr_write_address, pair.second->getRestoreOnBoot());
@@ -84,7 +84,7 @@ void EEPROMControlTask::save_sfr_data()
         }
 
         // Write SFR data age again. EEPROM restore will check that these ages match to determine if the last SFR save was completed.
-        EEPROM.put(sfr_write_address, sfr::eeprom::sfr_data_age.getFieldValue());
+        EEPROM.put(sfr_write_address, sfr::eeprom::sfr_data_age);
     }
 }
 

--- a/src/Control Tasks/EEPROMControlTask.cpp
+++ b/src/Control Tasks/EEPROMControlTask.cpp
@@ -10,21 +10,25 @@ void EEPROMControlTask::execute()
     sfr::eeprom::time_alive = millis();
 
     if (sfr::eeprom::time_alive - sfr::eeprom::last_fast_save_time > constants::eeprom::fast_write_interval && sfr::eeprom::boot_mode) {
+        // Adequate time has passed for a new write, and EEPROM is counting time in boot
         EEPROMControlTask::save_boot_time();
         sfr::eeprom::last_fast_save_time = sfr::eeprom::time_alive;
     }
 
     if (sfr::eeprom::time_alive - sfr::eeprom::last_fast_save_time > constants::eeprom::fast_write_interval && !sfr::eeprom::boot_mode && !sfr::eeprom::error_mode) {
+        // Adequate time has passed for a new write, and EEPROM has finished counting time in boot, and EEPROM is valid
         EEPROMControlTask::save_dynamic_data();
         sfr::eeprom::last_fast_save_time = sfr::eeprom::time_alive;
     }
 
     unsigned int write_interval = constants::eeprom::slow_write_interval;
     if (sfr::eeprom::light_switch) {
+        // Save SFR at a faster rate if the light switch is on
         write_interval = constants::eeprom::fast_write_interval;
     }
 
     if (sfr::eeprom::time_alive - sfr::eeprom::last_sfr_save_time > write_interval && !sfr::eeprom::boot_mode && !sfr::eeprom::error_mode) {
+        // Adequate time has passed for a new write, and EEPROM has finished counting time in boot, and EEPROM is valid
         EEPROMControlTask::save_sfr_data();
         sfr::eeprom::last_sfr_save_time = sfr::eeprom::time_alive;
     }
@@ -39,6 +43,7 @@ void EEPROMControlTask::save_boot_time()
 void EEPROMControlTask::save_dynamic_data()
 {
     if (sfr::eeprom::dynamic_data_age == 95000) {
+        // If write age reached, shift and save the dynamic data address
         sfr::eeprom::dynamic_data_addr += constants::eeprom::dynamic_data_full_offset;
         EEPROM.put(constants::eeprom::dynamic_data_addr_loc1, sfr::eeprom::dynamic_data_addr);
         EEPROM.put(constants::eeprom::dynamic_data_addr_loc2, sfr::eeprom::dynamic_data_addr);
@@ -46,7 +51,7 @@ void EEPROMControlTask::save_dynamic_data()
     }
 
     if (sfr::eeprom::dynamic_data_addr + constants::eeprom::dynamic_data_full_offset > constants::eeprom::sfr_data_start) {
-
+        // There is enough memory for another cycle of dynamic data
         sfr::eeprom::dynamic_data_age++;
         EEPROM.put(sfr::eeprom::dynamic_data_addr, sfr::eeprom::time_alive);
         EEPROM.put(sfr::eeprom::dynamic_data_addr + 4, sfr::eeprom::dynamic_data_age);
@@ -56,6 +61,7 @@ void EEPROMControlTask::save_dynamic_data()
 void EEPROMControlTask::save_sfr_data()
 {
     if (sfr::eeprom::sfr_data_age == 95000) {
+        // If write age reached, shift and save the SFR data address
         sfr::eeprom::sfr_data_age += constants::eeprom::sfr_data_full_offset;
         EEPROM.put(constants::eeprom::sfr_data_addr_loc1, sfr::eeprom::sfr_data_addr);
         EEPROM.put(constants::eeprom::sfr_data_addr_loc2, sfr::eeprom::sfr_data_addr);
@@ -63,8 +69,13 @@ void EEPROMControlTask::save_sfr_data()
     }
 
     if (sfr::eeprom::sfr_data_addr + constants::eeprom::sfr_data_full_offset > constants::eeprom::boot_counter_loc2) {
+        // There is enough memory for another cycle of SFR data
+
+        // Update and write SFR data age
         sfr::eeprom::sfr_data_age++;
         EEPROM.put(sfr::eeprom::sfr_data_addr, sfr::eeprom::sfr_data_age);
+
+        // Save SFR fields
         uint16_t sfr_write_address = sfr::eeprom::sfr_data_addr + 4;
         for (const auto &pair : SFRInterface::opcode_lookup) {
             EEPROM.put(sfr_write_address, pair.second->getRestoreOnBoot());
@@ -72,6 +83,7 @@ void EEPROMControlTask::save_sfr_data()
             sfr_write_address += constants::eeprom::sfr_store_size;
         }
 
+        // Write SFR data age again. EEPROM restore will check that these ages match to determine if the last SFR save was completed.
         EEPROM.put(sfr_write_address, sfr::eeprom::sfr_data_age);
     }
 }

--- a/src/Control Tasks/EEPROMControlTask.hpp
+++ b/src/Control Tasks/EEPROMControlTask.hpp
@@ -12,8 +12,9 @@ public:
     void execute();
 
 private:
+    void save_boot_time();
+    void save_dynamic_data();
     void save_sfr_data();
-    void check_wait_time();
 };
 
 #endif

--- a/src/Control Tasks/EEPROMControlTask.hpp
+++ b/src/Control Tasks/EEPROMControlTask.hpp
@@ -15,6 +15,10 @@ private:
     void save_boot_time();
     void save_dynamic_data();
     void save_sfr_data();
+
+    uint32_t last_boot_counter_save_time;
+    uint32_t last_dynamic_save_time;
+    uint32_t last_sfr_save_time;
 };
 
 #endif

--- a/src/EEPROMRestore.cpp
+++ b/src/EEPROMRestore.cpp
@@ -1,5 +1,4 @@
 #include "EEPROMRestore.hpp"
-// #include <algorithm> // find
 
 void EEPROMRestore::execute()
 {

--- a/src/EEPROMRestore.cpp
+++ b/src/EEPROMRestore.cpp
@@ -30,9 +30,9 @@ void EEPROMRestore::execute()
         // Not in boot mode, and boot time check didn't indicate EEPROM error
 
         // Fetch blue moon data
-        uint16_t boot_counter1;
+        uint8_t boot_counter1;
         EEPROM.get(constants::eeprom::boot_counter_loc1, boot_counter1);
-        uint16_t boot_counter2;
+        uint8_t boot_counter2;
         EEPROM.get(constants::eeprom::boot_counter_loc2, boot_counter2);
 
         uint16_t dynamic_data_addr1;
@@ -54,8 +54,8 @@ void EEPROMRestore::execute()
             // EEPROM data is valid
             sfr::eeprom::error_mode = false;
             sfr::eeprom::boot_counter = boot_counter1 + 1;
-            EEPROM.put(constants::eeprom::boot_counter_loc1, sfr::eeprom::boot_counter.getFieldValue());
-            EEPROM.put(constants::eeprom::boot_counter_loc2, sfr::eeprom::boot_counter.getFieldValue());
+            EEPROM.put(constants::eeprom::boot_counter_loc1, sfr::eeprom::boot_counter);
+            EEPROM.put(constants::eeprom::boot_counter_loc2, sfr::eeprom::boot_counter);
             sfr::eeprom::dynamic_data_addr = dynamic_data_addr1;
             sfr::eeprom::sfr_data_addr = sfr_data_addr1;
             sfr::eeprom::light_switch = light_switch1;

--- a/src/EEPROMRestore.cpp
+++ b/src/EEPROMRestore.cpp
@@ -1,50 +1,108 @@
 #include "EEPROMRestore.hpp"
+// #include <algorithm> // find
 
 void EEPROMRestore::execute()
 {
-    // The entire EEPROM memory will be zeroed before launch
-    uint8_t boot_counter;
-    EEPROM.get(4, boot_counter);
+    uint32_t boot_time1;
+    EEPROM.get(constants::eeprom::boot_time_loc1, boot_time1);
+    uint32_t boot_time2;
+    EEPROM.get(constants::eeprom::boot_time_loc2, boot_time2);
 
-    // On the very first boot up, place the sfr_address value in the appropriate byte. Do not restore anything from EEPROM and use the default values in the SFR
-    // On every boot up after, restore SFR values from EEPROM memory
-    if (boot_counter == 0) {
-        uint16_t sfr_address = sfr::eeprom::sfr_address; // By default, the sfr_address field in the SFR points to the beginning of the first byt section.
-        EEPROM.put(5, sfr_address);
+    if (boot_time1 == boot_time2) {
+        // Boot time counters are valid, check if initial two hour wait has passed
+        if (boot_time1 < 2 * constants::time::one_hour) {
+            sfr::eeprom::boot_mode = true;
+            sfr::eeprom::time_alive = boot_time1;
+        } else {
+            sfr::eeprom::boot_mode = false;
+            // Do not set time alive, boot time only counts up to two hours
+            // It will be restored with the dynamic data updated in the EEPROM Control Task now that the boot phase is over
+        }
+    } else {
+        // Boot time counters are invalid, zero out counters and start initial two hour wait
+        EEPROM.put(constants::eeprom::boot_time_loc1, (uint32_t)0);
+        EEPROM.put(constants::eeprom::boot_time_loc2, (uint32_t)0);
+        sfr::eeprom::boot_mode = true;
+        sfr::eeprom::time_alive = 0;
+        sfr::eeprom::error_mode = true;
     }
-    if (boot_counter != 0) {
-        uint16_t sfr_address;
-        EEPROM.get(5, sfr_address);
-        sfr::eeprom::sfr_address = sfr_address;
 
-        for (SFRInterface *s : SFRInterface::sfr_fields_vector) {
-            /*int read_address = sfr_address + s->getAddressOffset();
-            bool restore;
-            EEPROM.get(read_address, restore);
-            s->setRestore(restore);
-            if (restore) {
-                int data_type = s->getDataType();
-                if (data_type == 4) {
-                    uint32_t value;
-                    EEPROM.get(read_address + 1, value);
-                    s->setValue(value);
-                } else if (data_type == 3) {
-                    uint16_t value;
-                    EEPROM.get(read_address + 1, value);
-                    s->setValue(value);
-                } else if (data_type == 2) {
-                    uint8_t value;
-                    EEPROM.get(read_address + 1, value);
-                    s->setValue(value);
-                } else if (data_type == 1) {
-                    bool value;
-                    EEPROM.get(read_address + 1, value);
-                    s->setValue(value);
+    if (!sfr::eeprom::boot_mode && !sfr::eeprom::error_mode) {
+        // Not in boot mode, and boot time check didn't indicate EEPROM error
+
+        // Fetch blue moon data
+        uint16_t boot_counter1;
+        EEPROM.get(constants::eeprom::boot_counter_loc1, boot_counter1);
+        uint16_t boot_counter2;
+        EEPROM.get(constants::eeprom::boot_counter_loc2, boot_counter2);
+
+        uint16_t dynamic_data_addr1;
+        EEPROM.get(constants::eeprom::dynamic_data_addr_loc1, dynamic_data_addr1);
+        uint16_t dynamic_data_addr2;
+        EEPROM.get(constants::eeprom::dynamic_data_addr_loc2, dynamic_data_addr2);
+
+        uint16_t sfr_data_addr1;
+        EEPROM.get(constants::eeprom::sfr_data_addr_loc1, sfr_data_addr1);
+        uint16_t sfr_data_addr2;
+        EEPROM.get(constants::eeprom::sfr_data_addr_loc2, sfr_data_addr2);
+
+        bool light_switch1;
+        EEPROM.get(constants::eeprom::light_switch_loc1, light_switch1);
+        bool light_switch2;
+        EEPROM.get(constants::eeprom::light_switch_loc2, light_switch2);
+
+        if (boot_counter1 == boot_counter2 && dynamic_data_addr1 == dynamic_data_addr2 && sfr_data_addr1 == sfr_data_addr2 && light_switch1 == light_switch2) {
+            // EEPROM data is valid
+            sfr::eeprom::error_mode = false;
+            sfr::eeprom::boot_counter = boot_counter1 + 1;
+            EEPROM.get(constants::eeprom::boot_counter_loc1, sfr::eeprom::boot_counter);
+            EEPROM.get(constants::eeprom::boot_counter_loc2, sfr::eeprom::boot_counter);
+            sfr::eeprom::dynamic_data_addr = dynamic_data_addr1;
+            sfr::eeprom::sfr_data_addr = sfr_data_addr1;
+            sfr::eeprom::light_switch = light_switch1;
+        } else {
+            // EEPROM data is invalid
+            sfr::eeprom::error_mode = true;
+        }
+
+        if (!sfr::eeprom::error_mode && sfr::eeprom::light_switch) {
+            // EEPROM data is still valid after checks and light switch is on
+
+            // Fetch dynamic metadata
+            uint32_t time_alive;
+            EEPROM.get(sfr::eeprom::dynamic_data_addr, time_alive);
+            sfr::eeprom::time_alive = time_alive;
+
+            uint32_t dynamic_data_age;
+            EEPROM.get(sfr::eeprom::dynamic_data_addr + 4, dynamic_data_age);
+            sfr::eeprom::dynamic_data_age = dynamic_data_age;
+
+            uint32_t sfr_data_age1;
+            EEPROM.get(sfr::eeprom::sfr_data_addr, sfr_data_age1);
+
+            uint32_t sfr_data_age2;
+            EEPROM.get(sfr::eeprom::sfr_data_addr + constants::eeprom::sfr_data_full_offset - 4, sfr_data_age2);
+
+            sfr::eeprom::sfr_save_completed = sfr_data_age1 == sfr_data_age2; // Inequality means SFR didn't finish saving
+            sfr::eeprom::sfr_data_age = sfr_data_age1;                        // First age is the more accurate count
+
+            // If last SFR save was completed, restore desired SFR fields
+            if (sfr::eeprom::sfr_save_completed) {
+                uint16_t sfr_read_address = sfr::eeprom::sfr_data_addr + 4;
+                for (const auto &pair : SFRInterface::opcode_lookup) {
+                    bool restore;
+                    EEPROM.get(sfr_read_address, restore);
+                    pair.second->setRestoreOnBoot(restore);
+
+                    if (restore) {
+                        uint32_t value;
+                        EEPROM.get(sfr_read_address + 1, value);
+                        pair.second->setFieldValue(value);
+                    }
+
+                    sfr_read_address += constants::eeprom::sfr_store_size;
                 }
-            }*/
+            }
         }
     }
-    boot_counter++;
-    EEPROM.put(4, boot_counter);
-    sfr::eeprom::boot_counter = boot_counter;
 }

--- a/src/EEPROMRestore.cpp
+++ b/src/EEPROMRestore.cpp
@@ -54,8 +54,8 @@ void EEPROMRestore::execute()
             // EEPROM data is valid
             sfr::eeprom::error_mode = false;
             sfr::eeprom::boot_counter = boot_counter1 + 1;
-            EEPROM.put(constants::eeprom::boot_counter_loc1, sfr::eeprom::boot_counter);
-            EEPROM.put(constants::eeprom::boot_counter_loc2, sfr::eeprom::boot_counter);
+            EEPROM.put(constants::eeprom::boot_counter_loc1, sfr::eeprom::boot_counter.get());
+            EEPROM.put(constants::eeprom::boot_counter_loc2, sfr::eeprom::boot_counter.get());
             sfr::eeprom::dynamic_data_addr = dynamic_data_addr1;
             sfr::eeprom::sfr_data_addr = sfr_data_addr1;
             sfr::eeprom::light_switch = light_switch1;

--- a/src/EEPROMRestore.cpp
+++ b/src/EEPROMRestore.cpp
@@ -55,8 +55,8 @@ void EEPROMRestore::execute()
             // EEPROM data is valid
             sfr::eeprom::error_mode = false;
             sfr::eeprom::boot_counter = boot_counter1 + 1;
-            EEPROM.get(constants::eeprom::boot_counter_loc1, sfr::eeprom::boot_counter);
-            EEPROM.get(constants::eeprom::boot_counter_loc2, sfr::eeprom::boot_counter);
+            EEPROM.put(constants::eeprom::boot_counter_loc1, sfr::eeprom::boot_counter.getFieldValue());
+            EEPROM.put(constants::eeprom::boot_counter_loc2, sfr::eeprom::boot_counter.getFieldValue());
             sfr::eeprom::dynamic_data_addr = dynamic_data_addr1;
             sfr::eeprom::sfr_data_addr = sfr_data_addr1;
             sfr::eeprom::light_switch = light_switch1;

--- a/src/MainControlLoop.cpp
+++ b/src/MainControlLoop.cpp
@@ -169,7 +169,7 @@ void MainControlLoop::execute()
     camera_report_monitor.execute_on_time();
     imudownlink_report_monitor.execute_on_time();
 
-    eeprom_control_task.execute_on_time();
+    // eeprom_control_task.execute_on_time();
 
 #ifdef VERBOSE
     Serial.println("--------------------END LOOP--------------------");

--- a/src/MissionMode.cpp
+++ b/src/MissionMode.cpp
@@ -361,7 +361,7 @@ void exit_lp(MissionMode *reg_mode)
 
 void timed_out(MissionMode *next_mode, float max_time)
 {
-    if (millis() - sfr::mission::current_mode->start_time >= max_time) {
+    if (sfr::eeprom::time_alive - sfr::mission::current_mode->start_time >= max_time) {
         sfr::mission::current_mode = next_mode;
     }
 }

--- a/src/Monitors/NormalReportMonitor.cpp
+++ b/src/Monitors/NormalReportMonitor.cpp
@@ -118,16 +118,7 @@ uint8_t NormalReportMonitor::serialize(SensorReading *valueObj)
 uint8_t NormalReportMonitor::serialize(int opcode)
 {
     SFRInterface *valueObj = SFRInterface::opcode_lookup[opcode];
-    float value = 0;
-    int data_type = valueObj->getDataType();
-    if (data_type == 4)
-        value = (uint32_t)valueObj->getFieldValue();
-    else if (data_type == 3)
-        value = (uint16_t)valueObj->getFieldValue();
-    else if (data_type == 2)
-        value = (uint8_t)valueObj->getFieldValue();
-    else if (data_type == 1)
-        value = (bool)valueObj->getFieldValue();
+    float value = valueObj->getFieldValue();
 
     return serialize(value, valueObj->getMin(), valueObj->getMax());
 }

--- a/src/RockblockCommand.hpp
+++ b/src/RockblockCommand.hpp
@@ -81,10 +81,10 @@ public:
             uint8_t restore_value = constants::masks::uint32_byte4_mask & f_arg_2;       // Restore bit value
 
             if ((bool)set_value) {
-                field->setValue(f_arg_1);
+                field->setFieldValue(f_arg_1);
             }
             if ((bool)set_restore) {
-                field->setRestore((bool)restore_value);
+                field->setRestoreOnBoot((bool)restore_value);
             }
         }
     }

--- a/src/SFRField.cpp
+++ b/src/SFRField.cpp
@@ -1,48 +1,12 @@
 #include "SFRField.hpp"
 
 std::map<int, SFRInterface *> SFRInterface::opcode_lookup;
-std::vector<SFRInterface *> SFRInterface::sfr_fields_vector;
 
 void SFRInterface::setFieldValByOpcode(int opcode, uint32_t arg1)
 {
     if (opcode_lookup.count(opcode)) {
         // Valid Op Code
         SFRInterface *ptr = opcode_lookup[opcode];
-        ptr->setValue(arg1);
+        ptr->setFieldValue(arg1);
     }
-}
-
-int SFRInterface::getFieldValue()
-{
-    return field_value;
-}
-
-float SFRInterface::getMax()
-{
-    return max;
-}
-
-float SFRInterface::getMin()
-{
-    return min;
-}
-
-int SFRInterface::getDefaultValue()
-{
-    return default_value;
-}
-
-int SFRInterface::getDataType()
-{
-    return data_type;
-}
-
-void SFRInterface::setRestore(bool restore_on_boot)
-{
-    restore = restore_on_boot;
-}
-
-bool SFRInterface::getRestore()
-{
-    return restore;
 }

--- a/src/SFRField.hpp
+++ b/src/SFRField.hpp
@@ -10,20 +10,8 @@
 
 class SFRInterface
 {
-protected:
-    /* EEPROM saving and restoring uses a vector of SFRInterfaces, since C++ does not allow creating a vector
-    using the SFRField<T> template class, which means SFRField members and functions cannot be accessed. So,
-    we pass the SFRField data to the SFRInterface parent class cast to generic integers and booleans. */
-    int field_value;   // The value of the field cast to an int
-    int default_value; // The default value of the field cast to an int
-    int data_type;     // An int representing the field's type T, 1 for bool, 2 for uint8_t, 3 for uint16_t, and 4 for uint32_t
-    float min;
-    float max;
-    bool restore = false; // If the field should be restored or not
-
 public:
     static std::map<int, SFRInterface *> opcode_lookup; // </brief Op Code Lookup Map For SFR Field Uplink Override
-    static std::vector<SFRInterface *> sfr_fields_vector;
 
 #ifdef DEBUG
     static void resetSFR()
@@ -38,19 +26,14 @@ public:
 
     virtual ~SFRInterface(){};
     static void setFieldValByOpcode(int opcode, uint32_t arg1);
-    virtual void setValue(uint32_t arg1);
 
-    int getFieldValue();
+    virtual void setFieldValue(uint32_t arg1);
+    virtual uint32_t getFieldValue();
 
-    int getDefaultValue();
+    virtual uint32_t getDefaultValue();
 
-    int getDataType();
-
-    void setRestore(bool restore_on_boot);
-    bool getRestore();
-
-    float getMin();
-    float getMax();
+    virtual void setRestoreOnBoot(bool restore_on_boot);
+    virtual bool getRestoreOnBoot();
 };
 
 template <typename T, typename = typename std::enable_if<std::is_arithmetic<T>::value, T>::type>
@@ -58,121 +41,60 @@ class SFRField : public SFRInterface
 {
 private:
     T value;    // </brief Field Value, Only Arithmetic Types Allowed
+    T max;      // </brief Inclusive Minium Value
+    T min;      // </brief Inclusive Maximum Value
     int opcode; // </brief Uplink Op Code to set this field
-    int resolution = 1;
-#ifdef DEBUG
-    T initial;
-#endif
+    float resolution;
+    bool restore; // </brief Restore on boot from EEPROM flag
+    T initial;    // </brief Default field value
 
 public:
     SFRField(T default_val, T min, T max, int opcode_val)
     {
         value = default_val;
-        opcode = opcode_val;
-
-        field_value = (int)value;
-        default_value = (int)value;
         this->min = min;
         this->max = max;
-
-        if (sizeof(T) == sizeof(uint32_t))
-            data_type = 4;
-        else if (sizeof(T) == sizeof(uint16_t))
-            data_type = 3;
-        else if (sizeof(T) == sizeof(uint8_t))
-            data_type = 2;
-        else if (sizeof(T) == sizeof(bool))
-            data_type = 1;
-
-#ifdef DEBUG
+        opcode = opcode_val;
+        resolution = 1;
+        restore = false;
         T initial = default_val;
-#endif
-
         SFRInterface::opcode_lookup[opcode_val] = this;
-        SFRInterface::sfr_fields_vector.push_back(this);
     }
 
     SFRField(T default_val, int opcode_val)
     {
         value = default_val;
-        opcode = opcode_val;
-
-        field_value = (int)value;
-        default_value = (int)value;
         min = std::numeric_limits<T>::min();
         max = std::numeric_limits<T>::max();
-
-        if (sizeof(T) == sizeof(uint32_t))
-            data_type = 4;
-        else if (sizeof(T) == sizeof(uint16_t))
-            data_type = 3;
-        else if (sizeof(T) == sizeof(uint8_t))
-            data_type = 2;
-        else if (sizeof(T) == sizeof(bool))
-            data_type = 1;
-
-#ifdef DEBUG
+        opcode = opcode_val;
+        resolution = 1;
+        restore = false;
         T initial = default_val;
-#endif
-
         SFRInterface::opcode_lookup[opcode_val] = this;
-        SFRInterface::sfr_fields_vector.push_back(this);
     }
 
     SFRField(float default_val, float min, float max, int opcode_val, float resolution)
     {
         value = default_val * resolution;
-        opcode = opcode_val;
-        resolution = resolution;
-
-        field_value = (int)value;
-        default_value = (int)value;
         this->min = min;
         this->max = max;
-
-        if (sizeof(T) == sizeof(uint32_t))
-            data_type = 4;
-        else if (sizeof(T) == sizeof(uint16_t))
-            data_type = 3;
-        else if (sizeof(T) == sizeof(uint8_t))
-            data_type = 2;
-        else if (sizeof(T) == sizeof(bool))
-            data_type = 1;
-
-#ifdef DEBUG
-        T initial = default_val * resolution; // Since value gets set to initial in reset(), initial should be default_val * resolution instead of default_val
-#endif
-
+        opcode = opcode_val;
+        this->resolution = resolution;
+        restore = false;
+        T initial = default_val * resolution;
         SFRInterface::opcode_lookup[opcode_val] = this;
-        SFRInterface::sfr_fields_vector.push_back(this);
     }
 
     SFRField(float default_val, int opcode_val, float resolution)
     {
         value = default_val * resolution;
         opcode = opcode_val;
-        resolution = resolution;
-
-        field_value = (int)value;
-        default_value = (int)value;
-        this->min = min;
-        this->max = max;
-
-        if (sizeof(T) == sizeof(uint32_t))
-            data_type = 4;
-        else if (sizeof(T) == sizeof(uint16_t))
-            data_type = 3;
-        else if (sizeof(T) == sizeof(uint8_t))
-            data_type = 2;
-        else if (sizeof(T) == sizeof(bool))
-            data_type = 1;
-
-#ifdef DEBUG
-        T initial = default_val * resolution; // Since value gets set to initial in reset(), initial should be default_val * resolution instead of default_val
-#endif
-
+        min = std::numeric_limits<T>::min();
+        max = std::numeric_limits<T>::max();
+        this->resolution = resolution;
+        restore = false;
+        T initial = default_val * resolution;
         SFRInterface::opcode_lookup[opcode_val] = this;
-        SFRInterface::sfr_fields_vector.push_back(this);
     }
 
     operator T()
@@ -195,24 +117,41 @@ public:
         if (input <= max && input >= min) {
             value = input;
         }
-        field_value = (int)input;
     }
 
-#ifdef DEBUG
     void reset()
     {
         value = initial;
-        field_value = (int)initial;
+        restore = true;
     }
-#endif
-    void setValue(uint32_t arg1)
+
+    void setFieldValue(uint32_t arg1)
     {
         // Convert 32bit word into Target Type
-        // TODO Joining Two uint16s FS-158
         static_assert(sizeof(T) <= sizeof arg1, "Templated Type is larger than input.");
         T casted;
         std::memcpy(&casted, &arg1, sizeof(T));
         set(casted);
+    }
+
+    uint32_t getFieldValue()
+    {
+        return (uint32_t)value;
+    }
+
+    uint32_t getDefaultValue()
+    {
+        return (uint32_t)initial;
+    }
+
+    void setRestoreOnBoot(bool restore_on_boot)
+    {
+        restore = restore_on_boot;
+    }
+
+    bool getRestoreOnBoot()
+    {
+        return restore;
     }
 
     // Postfix increment operator.

--- a/src/SFRField.hpp
+++ b/src/SFRField.hpp
@@ -88,9 +88,9 @@ public:
     SFRField(float default_val, int opcode_val, float resolution)
     {
         value = default_val * resolution;
-        opcode = opcode_val;
         min = std::numeric_limits<T>::min();
         max = std::numeric_limits<T>::max();
+        opcode = opcode_val;
         this->resolution = resolution;
         restore = false;
         T initial = default_val * resolution;
@@ -128,7 +128,7 @@ public:
     void setFieldValue(uint32_t arg1)
     {
         // Convert 32bit word into Target Type
-        static_assert(sizeof(T) <= sizeof arg1, "Templated Type is larger than input.");
+        static_assert(sizeof(T) <= sizeof(arg1), "Templated Type is larger than input.");
         T casted;
         std::memcpy(&casted, &arg1, sizeof(T));
         set(casted);

--- a/src/SFRField.hpp
+++ b/src/SFRField.hpp
@@ -32,6 +32,9 @@ public:
 
     virtual uint32_t getDefaultValue();
 
+    virtual uint32_t getMin();
+    virtual uint32_t getMax();
+
     virtual void setRestoreOnBoot(bool restore_on_boot);
     virtual bool getRestoreOnBoot();
 };
@@ -142,6 +145,16 @@ public:
     uint32_t getDefaultValue()
     {
         return (uint32_t)initial;
+    }
+
+    uint32_t getMin()
+    {
+        return (uint32_t)min;
+    }
+
+    uint32_t getMax()
+    {
+        return (uint32_t)max;
     }
 
     void setRestoreOnBoot(bool restore_on_boot)

--- a/src/SFRField.hpp
+++ b/src/SFRField.hpp
@@ -122,7 +122,7 @@ public:
     void reset()
     {
         value = initial;
-        restore = true;
+        restore = false;
     }
 
     void setFieldValue(uint32_t arg1)

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -298,22 +298,22 @@ namespace constants {
         // Byte locations of the EEPROM blue moon data
         static constexpr unsigned int boot_time_loc1 = 0;
         static constexpr unsigned int boot_counter_loc1 = 4;
-        static constexpr unsigned int light_switch_loc1 = 6;
-        static constexpr unsigned int dynamic_data_addr_loc1 = 7;
-        static constexpr unsigned int sfr_data_addr_loc1 = 9;
+        static constexpr unsigned int light_switch_loc1 = 5;
+        static constexpr unsigned int dynamic_data_addr_loc1 = 6;
+        static constexpr unsigned int sfr_data_addr_loc1 = 8;
 
-        static constexpr unsigned int boot_time_loc2 = 4085;
-        static constexpr unsigned int boot_counter_loc2 = 4089;
+        static constexpr unsigned int boot_time_loc2 = 4086;
+        static constexpr unsigned int boot_counter_loc2 = 4090;
         static constexpr unsigned int light_switch_loc2 = 4091;
         static constexpr unsigned int dynamic_data_addr_loc2 = 4092;
         static constexpr unsigned int sfr_data_addr_loc2 = 4094;
 
         // Constants for saving data to EEPROM
         static constexpr unsigned int dynamic_data_full_offset = 8;
-        static constexpr unsigned int dynamic_data_start = 99;
-        static constexpr unsigned int sfr_data_start = 99;
+        static constexpr unsigned int dynamic_data_start = 10;
+        static constexpr unsigned int sfr_data_start = 90;
         static constexpr unsigned int sfr_store_size = 5;
-        static constexpr unsigned int sfr_num_fields = 100; // Number of fields
+        static constexpr unsigned int sfr_num_fields = 101;
         static constexpr unsigned int sfr_data_full_offset = sfr_num_fields * sfr_store_size + 8;
 
         static constexpr unsigned int fast_write_interval = 30 * constants::time::one_second;

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -2,8 +2,8 @@
 #define CONSTANTS_HPP_
 
 #include <cstddef>
-#include <map>
 #include <stdint.h>
+#include <vector>
 
 namespace constants {
     namespace time {
@@ -294,6 +294,31 @@ namespace constants {
         static constexpr unsigned int eeprom_control_task_offset = 0;
         static constexpr unsigned int mission_manager_offset = 0;
     } // namespace timecontrol
+    namespace eeprom {
+        // Byte locations of the EEPROM blue moon data
+        static constexpr unsigned int boot_time_loc1 = 0;
+        static constexpr unsigned int boot_counter_loc1 = 4;
+        static constexpr unsigned int light_switch_loc1 = 6;
+        static constexpr unsigned int dynamic_data_addr_loc1 = 7;
+        static constexpr unsigned int sfr_data_addr_loc1 = 9;
+
+        static constexpr unsigned int boot_time_loc2 = 4085;
+        static constexpr unsigned int boot_counter_loc2 = 4089;
+        static constexpr unsigned int light_switch_loc2 = 4091;
+        static constexpr unsigned int dynamic_data_addr_loc2 = 4092;
+        static constexpr unsigned int sfr_data_addr_loc2 = 4094;
+
+        // Constants for saving data to EEPROM
+        static constexpr unsigned int dynamic_data_full_offset = 8;
+        static constexpr unsigned int dynamic_data_start = 99;
+        static constexpr unsigned int sfr_data_start = 99;
+        static constexpr unsigned int sfr_store_size = 5;
+        static constexpr unsigned int sfr_num_fields = 100; // Number of fields
+        static constexpr unsigned int sfr_data_full_offset = sfr_num_fields * sfr_store_size + 8;
+
+        static constexpr unsigned int fast_write_interval = 30 * constants::time::one_second;
+        static constexpr unsigned int slow_write_interval = 5 * constants::time::one_minute;
+    } // namespace eeprom
 };    // namespace constants
 
 #endif

--- a/src/sfr.cpp
+++ b/src/sfr.cpp
@@ -283,17 +283,14 @@ namespace sfr {
     namespace eeprom {
         // OP Codes 2800
         SFRField<bool> boot_mode = SFRField<bool>(true, 0x2800);
-        SFRField<uint16_t> boot_counter = SFRField<uint16_t>(0, 0x2801);
-        SFRField<bool> error_mode = SFRField<bool>(true, 0x2802);
-        SFRField<uint16_t> dynamic_data_addr = SFRField<uint16_t>(constants::eeprom::dynamic_data_start, 0x2803);
-        SFRField<uint16_t> sfr_data_addr = SFRField<uint16_t>(constants::eeprom::sfr_data_start, 0x2804);
-        SFRField<bool> light_switch = SFRField<bool>(false, 0x2805);
-        SFRField<uint32_t> time_alive = SFRField<uint32_t>(0, 0x2806);
-        SFRField<uint32_t> dynamic_data_age = SFRField<uint32_t>(0, 0x2807);
-        SFRField<uint32_t> sfr_data_age = SFRField<uint32_t>(0, 0x2808);
-        SFRField<bool> sfr_save_completed = SFRField<bool>(false, 0x2809);
-
-        uint32_t last_fast_save_time = 0;
-        uint32_t last_sfr_save_time = 0;
+        SFRField<bool> error_mode = SFRField<bool>(true, 0x2801);
+        SFRField<bool> light_switch = SFRField<bool>(false, 0x2802);
+        SFRField<bool> sfr_save_completed = SFRField<bool>(false, 0x2803);
+        SFRField<uint8_t> boot_counter = SFRField<uint8_t>(0, 0x2804);
+        SFRField<uint16_t> dynamic_data_addr = SFRField<uint16_t>(constants::eeprom::dynamic_data_start, 0x2805);
+        SFRField<uint16_t> sfr_data_addr = SFRField<uint16_t>(constants::eeprom::sfr_data_start, 0x2806);
+        SFRField<uint32_t> time_alive = SFRField<uint32_t>(0, 0x2807);
+        SFRField<uint32_t> dynamic_data_age = SFRField<uint32_t>(0, 0x2808);
+        SFRField<uint32_t> sfr_data_age = SFRField<uint32_t>(0, 0x2809);
     } // namespace eeprom
 };    // namespace sfr

--- a/src/sfr.cpp
+++ b/src/sfr.cpp
@@ -282,20 +282,18 @@ namespace sfr {
     } // namespace pins
     namespace eeprom {
         // OP Codes 2800
-        SFRField<bool> allotted_time_passed = SFRField<bool>(false, 0x2800); // indicates if the EEPROM count has reached the alloted time
-        SFRField<bool> storage_full = SFRField<bool>(false, 0x2801);
-        // TODO need MIN and MAX
-        SFRField<uint8_t> boot_counter = SFRField<uint8_t>(0, 0, 0, 0x2802);
-        SFRField<uint32_t> wait_time_write_step_time = SFRField<uint32_t>(1000, 0x2803); // the amount of time between each write to EEPROM for wait time
-        SFRField<uint32_t> alloted_time = SFRField<uint32_t>(7200000, 0x2804);           // the amount of time for the EEPROM to count to (7200000 ms = 2 h)
-        SFRField<uint32_t> sfr_write_step_time = SFRField<uint32_t>(1000, 0x2805);       // the amount of time between each write to EEPROM for SFR data
-        SFRField<uint32_t> sfr_address_age = SFRField<uint32_t>(0, 0x2806);              // the write age of the current SFR data section in EEPROM
+        SFRField<bool> boot_mode = SFRField<bool>(true, 0x2800);
+        SFRField<uint16_t> boot_counter = SFRField<uint16_t>(0, 0x2801);
+        SFRField<bool> error_mode = SFRField<bool>(true, 0x2802);
+        SFRField<uint16_t> dynamic_data_addr = SFRField<uint16_t>(constants::eeprom::dynamic_data_start, 0x2803);
+        SFRField<uint16_t> sfr_data_addr = SFRField<uint16_t>(constants::eeprom::sfr_data_start, 0x2804);
+        SFRField<bool> light_switch = SFRField<bool>(false, 0x2805);
+        SFRField<uint32_t> time_alive = SFRField<uint32_t>(0, 0x2806);
+        SFRField<uint32_t> dynamic_data_age = SFRField<uint32_t>(0, 0x2807);
+        SFRField<uint32_t> sfr_data_age = SFRField<uint32_t>(0, 0x2808);
+        SFRField<bool> sfr_save_completed = SFRField<bool>(false, 0x2809);
 
-        // @ERIC fix if needed
-        int wait_time_last_write_time = 0; // the millis() value when the last EEPROM wait time write ocurred, should reset to 0 every boot up cycle
-        int sfr_last_write_time = 0;       // the millis() value when the last EEPROM SFR data write ocurred, should reset every boot up cycle
-        uint16_t sfr_address = 7;          // the address of where current SFR data is stored, read from EEPROM and set at the beginning of every boot up cycle
-        // Bytes 0-3 are for the time passed, byte 4 holds the number of reboots, and bytes 5-6 are for the address where values are to be written and stored.
-        // SFR data begins at byte 7 and after. The section of EEPROM bytes where SFR data is stored will change to avoid exceeding the write endurance.
+        uint32_t last_fast_save_time = 0;
+        uint32_t last_sfr_save_time = 0;
     } // namespace eeprom
 };    // namespace sfr

--- a/src/sfr.hpp
+++ b/src/sfr.hpp
@@ -279,16 +279,18 @@ namespace sfr {
     } // namespace pins
     namespace eeprom {
         // OP Codes 2800
-        extern SFRField<bool> allotted_time_passed;
-        extern SFRField<bool> storage_full;
-        extern SFRField<uint8_t> boot_counter;
-        extern SFRField<uint32_t> sfr_write_step_time;
-        extern SFRField<uint32_t> sfr_address_age;
-
-        // @ERIC fix if needed
-        extern int wait_time_last_write_time;
-        extern int sfr_last_write_time;
-        extern uint16_t sfr_address;
+        extern SFRField<bool> boot_mode;
+        extern SFRField<uint16_t> boot_counter;
+        extern SFRField<bool> error_mode;
+        extern SFRField<uint16_t> dynamic_data_addr;
+        extern SFRField<uint16_t> sfr_data_addr;
+        extern SFRField<bool> light_switch;
+        extern SFRField<uint32_t> time_alive;
+        extern SFRField<uint32_t> dynamic_data_age;
+        extern SFRField<uint32_t> sfr_data_age;
+        extern SFRField<bool> sfr_save_completed;
+        extern uint32_t last_fast_save_time;
+        extern uint32_t last_sfr_save_time;
     } // namespace eeprom
 };    // namespace sfr
 

--- a/src/sfr.hpp
+++ b/src/sfr.hpp
@@ -280,17 +280,15 @@ namespace sfr {
     namespace eeprom {
         // OP Codes 2800
         extern SFRField<bool> boot_mode;
-        extern SFRField<uint16_t> boot_counter;
         extern SFRField<bool> error_mode;
+        extern SFRField<bool> light_switch;
+        extern SFRField<bool> sfr_save_completed;
+        extern SFRField<uint8_t> boot_counter;
         extern SFRField<uint16_t> dynamic_data_addr;
         extern SFRField<uint16_t> sfr_data_addr;
-        extern SFRField<bool> light_switch;
         extern SFRField<uint32_t> time_alive;
         extern SFRField<uint32_t> dynamic_data_age;
         extern SFRField<uint32_t> sfr_data_age;
-        extern SFRField<bool> sfr_save_completed;
-        extern uint32_t last_fast_save_time;
-        extern uint32_t last_sfr_save_time;
     } // namespace eeprom
 };    // namespace sfr
 

--- a/test/test_eeprom/test_eeprom.cpp
+++ b/test/test_eeprom/test_eeprom.cpp
@@ -1,16 +1,7 @@
 #include <Control Tasks/EEPROMControlTask.hpp>
 #include <EEPROMRestore.hpp>
+#include <SFRField.hpp>
 #include <unity.h>
-
-/* Sets SFR fields to their default values and their restore boolean as true. */
-void resetSFR()
-{
-    for (auto const &kv : SFRInterface::opcode_lookup) {
-        int default_value = SFRInterface::opcode_lookup[kv.first]->getDefaultValue();
-        SFRInterface::opcode_lookup[kv.first]->setValue(default_value);
-        SFRInterface::opcode_lookup[kv.first]->setRestore(true);
-    }
-}
 
 /* Zeroes out all EEPROM bytes. */
 void clear_eeprom()
@@ -25,7 +16,7 @@ void test_restore_first_boot()
 {
     // Setup
     clear_eeprom();
-    resetSFR();
+    SFRInterface::resetSFR();
     EEPROMControlTask eeprom_control_task(0);
 
     // Check the boot counter byte in EEPROM is 0 before the first restore execution
@@ -64,7 +55,7 @@ void test_execute_no_write()
 {
     // Setup
     clear_eeprom();
-    resetSFR();
+    SFRInterface::resetSFR();
     EEPROMControlTask eeprom_control_task(0);
     EEPROM.write(4, 1);                      // Change the 4th byte (the boot counter) to non-zero
     EEPROM.put(5, sfr::eeprom::sfr_address); // Change the 5-6 bytes to point to the SFR data section in EEPROM
@@ -97,7 +88,7 @@ void test_execute_no_write()
     EEPROM.get(4, boot_counter_before);
 
     // Set all SFR fields to default values and restore booleans to true (as would happen on a reboot)
-    resetSFR();
+    SFRInterface::resetSFR();
 
     // Restore SFR values from EEPROM and check their values and restore booleans
     EEPROMRestore::execute();
@@ -125,7 +116,7 @@ void test_restore_general_reboot()
 {
     // Setup
     clear_eeprom();
-    resetSFR();
+    SFRInterface::resetSFR();
     EEPROMControlTask eeprom_control_task(0);
     EEPROM.write(4, 1);                      // Change the 4th byte (the boot counter) to non-zero
     EEPROM.put(5, sfr::eeprom::sfr_address); // Change the 5-6 bytes to point to the SFR section in EEPROM
@@ -157,7 +148,7 @@ void test_restore_general_reboot()
     EEPROM.get(4, boot_counter_before);
 
     // Set all SFR fields to default values and restore booleans to true (as would happen on a reboot)
-    resetSFR();
+    SFRInterface::resetSFR();
 
     // Restore SFR values from EEPROM and check their values and restore booleans
     EEPROMRestore::execute();
@@ -207,7 +198,7 @@ void test_restore_multiple_writes()
 {
     // Setup
     clear_eeprom();
-    resetSFR();
+    SFRInterface::resetSFR();
     EEPROMControlTask eeprom_control_task(0);
     EEPROM.write(4, 1);                      // Change the 4th byte (the boot counter) to non-zero
     EEPROM.put(5, sfr::eeprom::sfr_address); // Change the 5-6 bytes to point to the SFR section in EEPROM
@@ -262,7 +253,7 @@ void test_restore_multiple_writes()
     EEPROM.get(4, boot_counter_before);
 
     // Set all SFR fields to default values and restore booleans to true (as would happen on a reboot)
-    resetSFR();
+    SFRInterface::resetSFR();
 
     // Restore SFR values from EEPROM and check that they match the final write
     EEPROMRestore::execute();
@@ -312,7 +303,7 @@ void test_restore_write_limit_reboot()
 {
     // Setup
     clear_eeprom();
-    resetSFR();
+    SFRInterface::resetSFR();
     EEPROMControlTask eeprom_control_task(0);
     EEPROM.write(4, 1);                      // Change the 4th byte (the boot counter) to non-zero
     EEPROM.put(5, sfr::eeprom::sfr_address); // Change the 5-6 bytes to point to the SFR section in EEPROM
@@ -349,7 +340,7 @@ void test_restore_write_limit_reboot()
     EEPROM.get(4, boot_counter_before);
 
     // Set all SFR fields to default values and restore booleans to true (as would happen on a reboot)
-    resetSFR();
+    SFRInterface::resetSFR();
 
     // Restore SFR values from EEPROM and check their values and restore booleans
     EEPROMRestore::execute();
@@ -390,10 +381,11 @@ void test_restore_write_limit_reboot()
     }
 }
 
-void test_exceed_eeprom_memory() {
+void test_exceed_eeprom_memory()
+{
     // Setup
     clear_eeprom();
-    resetSFR();
+    SFRInterface::resetSFR();
     EEPROMControlTask eeprom_control_task(0);
 
     // Set the SFR address to the last byte of the EEPROM memory so there is not enough room for a full store
@@ -408,7 +400,7 @@ void test_time_tracker()
 {
     // Setup, SFR bytes are not tested in this test case
     clear_eeprom();
-    resetSFR();
+    SFRInterface::resetSFR();
     EEPROMControlTask eeprom_control_task(0);
 
     // Delay for over the write time step, save the initial time count from EEPROM


### PR DESCRIPTION
# EEPROM rework

This is the initial implementation with the calls to the Control Task and Restore commented out. When I run my test cases on it and verify it works I'll uncomment. Has new SFRFields relevant to the normal report and also now using time_alive to check if the initial two hours have passed.