### PR TITLE
Update sensor reading logic

### DIFF
--- a/src/MissionMode.cpp
+++ b/src/MissionMode.cpp
@@ -253,7 +253,7 @@ void RegularBurns::transition_to()
 
 void RegularBurns::dispatch()
 {
-    if (!sfr::button::pressed || !sfr::photoresistor::covered) {
+    if ((!sfr::button::pressed && !fault_groups::hardware_faults::button->get_signaled()) || (!sfr::photoresistor::covered && !fault_groups::hardware_faults::light_val->get_signaled())) {
         sfr::mission::current_mode = sfr::mission::photo;
 
     } else if (sfr::burnwire::attempts > sfr::burnwire::attempts_limit) {

--- a/src/Monitors/ButtonMonitor.cpp
+++ b/src/Monitors/ButtonMonitor.cpp
@@ -12,10 +12,9 @@ void ButtonMonitor::execute()
 
     // button is recognized as not pressed
     if (val == 0) {
-        // it is possible for the button to be unpressed
-        if (sfr::mission::possible_uncovered) {
-            sfr::button::pressed = false;
-        } else {
+        sfr::button::pressed = false;
+        // if it is not possible for the button to be unpressed
+        if (!sfr::mission::possible_uncovered) {
             sfr::button::button_pressed->set_invalid();
             fault_groups::hardware_faults::button->force();
         }

--- a/src/Monitors/CurrentMonitor.cpp
+++ b/src/Monitors/CurrentMonitor.cpp
@@ -9,8 +9,7 @@ CurrentMonitor::CurrentMonitor(unsigned int offset)
 void CurrentMonitor::execute()
 {
     if (!initialized) {
-        sfr::photoresistor::light_val_average_standby->set_valid();
-        sfr::photoresistor::light_val_average_deployment->set_valid();
+        sfr::current::solar_current_average->set_valid();
         initialized = true;
     }
 

--- a/src/Monitors/PhotoresistorMonitor.cpp
+++ b/src/Monitors/PhotoresistorMonitor.cpp
@@ -18,30 +18,32 @@ void PhotoresistorMonitor::execute()
 
     sfr::photoresistor::light_val_average_standby->set_value(val);
     sfr::photoresistor::light_val_average_deployment->set_value(val);
+    bool avg_buffer_valid = sfr::photoresistor::light_val_average_standby->get_value(&val);
+    bool deploy_buffer_valid = sfr::photoresistor::light_val_average_deployment->get_value(&val) && val > constants::photoresistor::light_val;
 
-    // photoresistor is recognized as uncovered
-    if ((sfr::photoresistor::light_val_average_standby->get_value(&val) || sfr::photoresistor::light_val_average_deployment->get_value(&val)) && val > constants::photoresistor::light_val) {
-        for (int mission_mode : sfr::mission::mode_history) {
-            // checks if mission mode has never reached burn
-            if (mission_mode >= sfr::mission::mandatoryBurns->get_id()) {
-                possible_uncovered = true;
+    // if sun detected, set photoresistor to uncovered (regardless of validity)
+    if (val > constants::photoresistor::light_val) {
+        sfr::photoresistor::covered = false;
+        // if either buffer is valid, check whether to invalidate
+        if (avg_buffer_valid || deploy_buffer_valid) {
+            for (int mission_mode : sfr::mission::mode_history) {
+                // checks if mission mode has never reached burn
+                if (mission_mode >= sfr::mission::mandatoryBurns->get_id()) {
+                    possible_uncovered = true;
+                }
             }
-        }
 
-        // is it possible for the photoresistor to be uncovered
-        if (possible_uncovered) {
-            // photoresistor is recognized as uncovered (via singleton buffer)
-            if (sfr::photoresistor::light_val_average_deployment->get_value(&val) && val > constants::photoresistor::light_val) {
-                sfr::photoresistor::covered = false;
-            }
-        } else {
-            // photoresistor is recognized as uncovered (via 4 second buffer)
-            if (sfr::photoresistor::light_val_average_standby->get_value(&val) && val > constants::photoresistor::light_val) {
-                sfr::photoresistor::light_val_average_standby->set_invalid();
+            // set buffer to invalid if never reached burn
+            if (!possible_uncovered) {
+                if (sfr::photoresistor::light_val_average_standby->get_value(&val)) {
+                    sfr::photoresistor::light_val_average_standby->set_invalid();
+                } else {
+                    sfr::photoresistor::light_val_average_deployment->set_invalid();
+                }
                 fault_groups::hardware_faults::light_val->force();
             }
         }
-
+        // if dark, set photoresistor to covered
     } else {
         sfr::photoresistor::covered = true;
     }


### PR DESCRIPTION
# Update Sensor Reading Logic

Modifies sensor reading logic to provide clearer insight into sensor states during DITL testing. Also ensures that sensor states do not get permanently stuck under certain initialization conditions. 

### Summary of changes
- Update PhotoresistorMonitor.cpp to trigger light condition regardless of buffer validity 
- Update ButtonMonitor.cpp to trigger unpressed condition regardless of buffer validity 
- Update MissionMode.cpp to transition to Photo mode only when button/photoresistor indication is valid
- Correct extraneous modification of photoresistor buffer in CurrentMonitor.cpp

### Testing
Tested on flatsat

### SFR Changes
N/A

### Documentation Evidence
Inline documentation is sufficient