### PR TITLE
add boot time mins to normal report

### DIFF
--- a/src/ClockManager.cpp
+++ b/src/ClockManager.cpp
@@ -19,6 +19,7 @@ void ClockManager::execute()
     TimedControlTaskBase::control_cycle_start_time = get_system_time();
     control_cycle_count++;
     sfr::mission::cycle_no++;
+    sfr::mission::boot_time_mins = sfr::mission::cycle_no % (constants::time::one_minute / constants::timecontrol::control_cycle_time_ms);
     sfr::mission::cycle_dur = constants::timecontrol::control_cycle_time - cycle_dt;
 }
 

--- a/src/Monitors/NormalReportMonitor.cpp
+++ b/src/Monitors/NormalReportMonitor.cpp
@@ -18,9 +18,8 @@ void NormalReportMonitor::execute()
     bool eeprom_bools[] = {0, 0, 0, 0, sfr::eeprom::boot_restarted, sfr::eeprom::error_mode, sfr::eeprom::light_switch, sfr::eeprom::sfr_save_completed};
 
     std::vector<uint8_t> report_contents{
-        constants::rockblock::start_of_normal_downlink,
-
         // SFR fields
+        serialize(0x1805), // sfr::mission::boot_time_mins
         serialize(0x1905), // sfr::burnwire::burn_time
         serialize(0x1906), // sfr::burnwire::armed_time
         serialize(0x2111), // sfr::rockblock::lp_downlink_period

--- a/src/Monitors/NormalReportMonitor.cpp
+++ b/src/Monitors/NormalReportMonitor.cpp
@@ -19,7 +19,7 @@ void NormalReportMonitor::execute()
 
     std::vector<uint8_t> report_contents{
         // SFR fields
-        serialize(0x1805), // sfr::mission::boot_time_mins
+        serialize(0x1802), // sfr::mission::boot_time_mins
         serialize(0x1905), // sfr::burnwire::burn_time
         serialize(0x1906), // sfr::burnwire::armed_time
         serialize(0x2111), // sfr::rockblock::lp_downlink_period

--- a/src/sfr.cpp
+++ b/src/sfr.cpp
@@ -35,10 +35,10 @@ namespace sfr {
         // OP Codes 1800
         SFRField<bool> deployed = SFRField<bool>(false, 0x1800);
         SFRField<bool> possible_uncovered = SFRField<bool>(false, 0x1801);
-        SFRField<uint32_t> mission_mode_hist_length = SFRField<uint32_t>(20, 0x1802);
-        SFRField<uint32_t> cycle_no = SFRField<uint32_t>(0, 0x1803);
-        SFRField<uint32_t> cycle_dur = SFRField<uint32_t>(0, 0x1804);
-        SFRField<uint8_t> boot_time_mins = SFRField<uint8_t>(0, 0x1805);
+        SFRField<uint8_t> boot_time_mins = SFRField<uint8_t>(0, 0x1802);
+        SFRField<uint32_t> mission_mode_hist_length = SFRField<uint32_t>(20, 0x1803);
+        SFRField<uint32_t> cycle_no = SFRField<uint32_t>(0, 0x1804);
+        SFRField<uint32_t> cycle_dur = SFRField<uint32_t>(0, 0x1805);
 
         Boot boot_class;
         AliveSignal aliveSignal_class;

--- a/src/sfr.cpp
+++ b/src/sfr.cpp
@@ -38,6 +38,7 @@ namespace sfr {
         SFRField<uint32_t> mission_mode_hist_length = SFRField<uint32_t>(20, 0x1802);
         SFRField<uint32_t> cycle_no = SFRField<uint32_t>(0, 0x1803);
         SFRField<uint32_t> cycle_dur = SFRField<uint32_t>(0, 0x1804);
+        SFRField<uint8_t> boot_time_mins = SFRField<uint8_t>(0,0x1805);
 
         Boot boot_class;
         AliveSignal aliveSignal_class;

--- a/src/sfr.cpp
+++ b/src/sfr.cpp
@@ -38,7 +38,7 @@ namespace sfr {
         SFRField<uint32_t> mission_mode_hist_length = SFRField<uint32_t>(20, 0x1802);
         SFRField<uint32_t> cycle_no = SFRField<uint32_t>(0, 0x1803);
         SFRField<uint32_t> cycle_dur = SFRField<uint32_t>(0, 0x1804);
-        SFRField<uint8_t> boot_time_mins = SFRField<uint8_t>(0,0x1805);
+        SFRField<uint8_t> boot_time_mins = SFRField<uint8_t>(0, 0x1805);
 
         Boot boot_class;
         AliveSignal aliveSignal_class;

--- a/src/sfr.hpp
+++ b/src/sfr.hpp
@@ -57,6 +57,8 @@ namespace sfr {
         extern SFRField<uint32_t> mission_mode_hist_length;
         extern SFRField<uint32_t> cycle_no;
         extern SFRField<uint32_t> cycle_dur;
+        extern SFRField<uint8_t> boot_time_mins;
+
 
         extern Boot boot_class;
         extern AliveSignal aliveSignal_class;

--- a/src/sfr.hpp
+++ b/src/sfr.hpp
@@ -59,7 +59,6 @@ namespace sfr {
         extern SFRField<uint32_t> cycle_dur;
         extern SFRField<uint8_t> boot_time_mins;
 
-
         extern Boot boot_class;
         extern AliveSignal aliveSignal_class;
         extern LowPowerAliveSignal lowPowerAliveSignal_class;

--- a/src/sfr.hpp
+++ b/src/sfr.hpp
@@ -54,10 +54,10 @@ namespace sfr {
         // OP Codes 1800
         extern SFRField<bool> deployed;
         extern SFRField<bool> possible_uncovered;
+        extern SFRField<uint8_t> boot_time_mins;
         extern SFRField<uint32_t> mission_mode_hist_length;
         extern SFRField<uint32_t> cycle_no;
         extern SFRField<uint32_t> cycle_dur;
-        extern SFRField<uint8_t> boot_time_mins;
 
         extern Boot boot_class;
         extern AliveSignal aliveSignal_class;


### PR DESCRIPTION
# PR Title

Fixes #. (Link to jira ticket this fixes)

### Summary of changes
- add boot time mins to normal report (every minute it increases by one)

### Testing

Deferring testing to Nominal test

### SFR Changes
Added sfr::mission::boot_time_mins

### Documentation Evidence

Kind of self documenting