### PR TITLE
Update normal report

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@ Describe your testing. The testing should be at a level appropriate to demonstra
 If your update does not require significant testing, argue why, or if you're deferring testing to another PR, create an issue ticket for the deferral and link it.
 
 ### SFR Changes
-Describe any important diffs to the SFR. Ensure that any fields you added to the code successfully made it into the SFR file. Also if the changes are an SFRField, make sure to update the EEPROM offset constants to account for the new fields.
+Describe any important diffs to the SFR. Ensure that any fields you added to the code successfully made it into the SFR file. Also if you add or remove any SFR fields, update constants::epprom::sfr_num_fields appropriately.
 
 Finally, Make sure to determine if these changes open any follow up tasks, (whether it be with the normal report, EEPROM, etc.) and link an issue ticket if necessary here.
 

--- a/src/MissionManager.cpp
+++ b/src/MissionManager.cpp
@@ -24,7 +24,7 @@ void MissionManager::execute()
     if (sfr::mission::previous_mode->get_id() != sfr::mission::current_mode->get_id()) {
         sfr::mission::current_mode->set_start_time(millis());
         sfr::mission::current_mode->transition_to();
-        if (sfr::mission::mode_history.size() >= sfr::mission::mission_mode_hist_length) {
+        if (sfr::mission::mode_history.size() >= constants::rockblock::mission_mode_hist_length) {
             sfr::mission::mode_history.pop_back();
         }
         sfr::mission::mode_history.push_front(sfr::mission::current_mode->get_id());

--- a/src/Monitors/CameraReportMonitor.cpp
+++ b/src/Monitors/CameraReportMonitor.cpp
@@ -73,7 +73,8 @@ void CameraReportMonitor::create_camera_report(int fragment_number, uint8_t seri
     }
     imgFile.close();
 
-    sfr::rockblock::camera_report.push_back(42);
+    sfr::rockblock::camera_report.push_back(constants::rockblock::camera_report_flag);
+
     // get each byte of serial number and add to camera report
     sfr::rockblock::camera_report.push_back(serial_number);
 

--- a/src/Monitors/IMUDownlinkReportMonitor.cpp
+++ b/src/Monitors/IMUDownlinkReportMonitor.cpp
@@ -26,7 +26,7 @@ void IMUDownlinkReportMonitor::create_imu_downlink_report(int fragment_number)
     }
 
     // Push report ID
-    sfr::rockblock::imu_report.push_back(24);
+    sfr::rockblock::imu_report.push_back(constants::rockblock::imu_report_flag);
 
     // Push fragment number to the report
     sfr::rockblock::imu_report.push_back(fragment_number);

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -288,7 +288,7 @@ namespace constants {
         static constexpr unsigned int dynamic_data_start = 10;
         static constexpr unsigned int sfr_data_start = 460;
         static constexpr unsigned int sfr_store_size = 5;
-        static constexpr unsigned int sfr_num_fields = 96;
+        static constexpr unsigned int sfr_num_fields = 95;
         static constexpr unsigned int sfr_data_full_offset = sfr_num_fields * sfr_store_size + 8;
         static constexpr unsigned int write_age_limit = 95000; // Must be less than 100000
 

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -29,7 +29,8 @@ namespace constants {
         constexpr int second_pin = 15;
     } // namespace burnwire
     namespace rockblock {
-        constexpr int normal_report_command_max = 10;
+        constexpr int normal_report_command_max = 9;
+        constexpr int mission_mode_hist_length = 16;
         constexpr int content_length = 68;
         constexpr int sleep_pin = 19;
         constexpr int min_sleep_period = 2 * time::one_minute;
@@ -44,6 +45,10 @@ namespace constants {
         constexpr size_t arg2_len = 4;
         constexpr size_t command_len = opcode_len + arg1_len + arg2_len;
         constexpr size_t max_conseq_read = 3;
+
+        constexpr uint8_t normal_report_flag = 99;
+        constexpr uint8_t imu_report_flag = 24;
+        constexpr uint8_t camera_report_flag = 42;
 
         constexpr uint8_t end_of_command_upload_flag1 = 0;
         constexpr uint8_t end_of_command_upload_flag2 = 250;

--- a/src/sfr.cpp
+++ b/src/sfr.cpp
@@ -39,9 +39,8 @@ namespace sfr {
         SFRField<bool> deployed = SFRField<bool>(false, 0x1800);
         SFRField<bool> possible_uncovered = SFRField<bool>(false, 0x1801);
         SFRField<uint8_t> boot_time_mins = SFRField<uint8_t>(0, 0x1802);
-        SFRField<uint32_t> mission_mode_hist_length = SFRField<uint32_t>(16, 0x1803);
-        SFRField<uint32_t> cycle_no = SFRField<uint32_t>(0, 0x1804);
-        SFRField<uint32_t> cycle_start = SFRField<uint32_t>(0, 0x1805);
+        SFRField<uint32_t> cycle_no = SFRField<uint32_t>(0, 0x1803);
+        SFRField<uint32_t> cycle_start = SFRField<uint32_t>(0, 0x1804);
 
         Boot boot_class;
         AliveSignal aliveSignal_class;

--- a/src/sfr.hpp
+++ b/src/sfr.hpp
@@ -56,7 +56,6 @@ namespace sfr {
         extern SFRField<bool> deployed;
         extern SFRField<bool> possible_uncovered;
         extern SFRField<uint8_t> boot_time_mins;
-        extern SFRField<uint32_t> mission_mode_hist_length;
         extern SFRField<uint32_t> cycle_no;
         extern SFRField<uint32_t> cycle_start;
 


### PR DESCRIPTION
### Summary of changes
- Add normal report flag and acs_mode to normal report, decreased downlinked command opcodes by 1 (now 9)
- Created constants for report flags, made mission_mode_hist_length a constant as well

### Testing
Deferred to nominal test.

### Documentation Evidence
Documentation is sufficient.