### PR TITLE
Fix empty IMU reports.

### DIFF
--- a/src/Monitors/IMUDownlinkReportMonitor.cpp
+++ b/src/Monitors/IMUDownlinkReportMonitor.cpp
@@ -22,8 +22,12 @@ void IMUDownlinkReportMonitor::create_imu_downlink_report(int fragment_number)
     // Set report is not ready if imu_dlink is empty and all fragments have been downlinked
     if (sfr::imu::imu_dlink.size() == 0 && sfr::rockblock::imu_report.size() == 0) {
         sfr::imu::report_ready = false;
+        sfr::rockblock::imu_report.clear();
         return;
     }
+
+    // Sets the amount of values that go into the report.
+    int pop_size = min(constants::imu::max_gyro_imu_report_size, sfr::imu::imu_dlink.size());
 
     // Push report ID
     sfr::rockblock::imu_report.push_back(24);

--- a/src/Monitors/IMUDownlinkReportMonitor.hpp
+++ b/src/Monitors/IMUDownlinkReportMonitor.hpp
@@ -18,8 +18,6 @@ private:
     uint8_t fragment_number = 0;
     bool report_ready = false;
     bool report_downlinked = true;
-    // Sets the amount of values that go into the report.
-    int pop_size = min(constants::imu::max_gyro_imu_report_size, sfr::imu::imu_dlink.size());
 };
 
 #endif


### PR DESCRIPTION
# PR Title: Fix empty IMU reports

Fixes #. (Link to jira ticket this fixes)

### Summary of changes
- Cleared the report once the buffer was empty and there was no data to collect.
- Included the pop size to be updated every time we create a new report.
-

If it applies, take a chance to describe offshoot work or TODOs that are a part of your PR.

### Testing
Describe your testing. The testing should be at a level appropriate to demonstrate that your feature is sufficiently tested.

If your update does not require significant testing, argue why, or if you're deferring testing to another PR, create an issue ticket for the deferral and link it.

-Testing was done but a nominal test needs to be run to test the long-duration testing.

### SFR Changes
Describe any important diffs to the SFR. Ensure that any fields you added to the code successfully made it into the SFR file. Also if you add or remove any SFR fields, update constants::epprom::sfr_num_fields appropriately.

Finally, Make sure to determine if these changes open any follow up tasks, (whether it be with the normal report, EEPROM, etc.) and link an issue ticket if necessary here.

### Documentation Evidence
Post to the wiki, or one of the following
- Argue that your inline documentation is sufficient.
- Create and link an issue ticket deferring the documentation task.