### PR TITLE
Switched String class in reset_eeprom

### DIFF
--- a/src/Control Tasks/RockblockControlTask.cpp
+++ b/src/Control Tasks/RockblockControlTask.cpp
@@ -11,7 +11,7 @@ void RockblockControlTask::execute()
 {
     rockblock_mode_type mode = static_cast<rockblock_mode_type>(sfr::rockblock::mode.get());
 
-    if(sfr::rockblock::sleep_mode){
+    if (sfr::rockblock::sleep_mode) {
         sfr::rockblock::mode = (uint16_t)rockblock_mode_type::standby;
     }
 

--- a/tools/reset_eeprom.cpp
+++ b/tools/reset_eeprom.cpp
@@ -1,7 +1,6 @@
 #include <Arduino.h>
 #include <EEPROM.h>
 #include <SD.h>
-#include <string>
 
 #define NUM_FILES 10
 
@@ -23,7 +22,7 @@ void setup()
     if (create_files) {
 
         for (int i = 0; i < NUM_FILES; i++) {
-            std::string filename = "file" + std::to_string(i) + ".txt";
+            String filename = "file" + String(i) + ".txt";
             File file = SD.open(filename.c_str(), FILE_WRITE);
             Serial.print("Creating ");
             Serial.println(filename.c_str());


### PR DESCRIPTION
Replaces the C++ `<string>` library with Teensy's `String` class in `tools/reset_eeprom.cpp`.