### PR TITLE
Report Rotation

### DIFF
--- a/src/Monitors/RockblockReportMonitor.cpp
+++ b/src/Monitors/RockblockReportMonitor.cpp
@@ -18,13 +18,10 @@ void RockblockReportMonitor::execute()
 
     switch (static_cast<report_type>(sfr::rockblock::downlink_report_type.get())) {
     case report_type::camera_report:
-        if (last_report_type != report_type::camera_report) {
-            sfr::rockblock::downlink_report.clear();
-            for (auto &data : sfr::rockblock::camera_report) {
-                sfr::rockblock::downlink_report.push_back(data);
-            }
+        sfr::rockblock::downlink_report.clear();
+        for (auto &data : sfr::rockblock::camera_report) {
+            sfr::rockblock::downlink_report.push_back(data);
         }
-        last_report_type = report_type::camera_report;
         return;
 
     case report_type::normal_report:
@@ -32,17 +29,13 @@ void RockblockReportMonitor::execute()
         for (auto &data : sfr::rockblock::normal_report) {
             sfr::rockblock::downlink_report.push_back(data);
         }
-        last_report_type = report_type::normal_report;
         return;
 
     case report_type::imu_report:
-        if (last_report_type != report_type::imu_report) {
-            sfr::rockblock::downlink_report.clear();
-            for (auto &data : sfr::rockblock::imu_report) {
-                sfr::rockblock::downlink_report.push_back(data);
-            }
+        sfr::rockblock::downlink_report.clear();
+        for (auto &data : sfr::rockblock::imu_report) {
+            sfr::rockblock::downlink_report.push_back(data);
         }
-        last_report_type = report_type::imu_report;
         return;
     }
 }

--- a/src/Monitors/RockblockReportMonitor.cpp
+++ b/src/Monitors/RockblockReportMonitor.cpp
@@ -50,75 +50,37 @@ void RockblockReportMonitor::schedule_report()
 {
 
     // Check if in a low-power mode; if so, only enable normal report downlink
-    if (sfr::mission::current_mode->get_type() == mode_type::LP) {
-        if (millis() - sfr::rockblock::last_downlink >= sfr::rockblock::downlink_period) {
+    if (millis() - sfr::rockblock::last_downlink >= sfr::rockblock::downlink_period) {
+        if (sfr::mission::current_mode->get_type() == mode_type::LP) {
             sfr::rockblock::downlink_report_type = (uint16_t)report_type::normal_report;
             sfr::rockblock::ready_status = true;
             return;
+        } else {
+            // Not in low-power mode; report type cycle order: normal report, IMU report, camera report
+            switch (static_cast<report_type>(sfr::rockblock::downlink_report_type.get())) {
+            case report_type::normal_report:
+                if (sfr::camera::report_ready) {
+                    switch_report_type_to(report_type::camera_report);
+                    return;
+                } else if (sfr::imu::report_ready) {
+                    switch_report_type_to(report_type::imu_report);
+                    return;
+                }
+                switch_report_type_to(report_type::normal_report);
+                return;
+            case report_type::camera_report:
+                if (sfr::imu::report_ready) {
+                    switch_report_type_to(report_type::imu_report);
+                    return;
+                }
+                switch_report_type_to(report_type::normal_report);
+                return;
+            case report_type::imu_report:
+                switch_report_type_to(report_type::normal_report);
+                return;
+            }
         }
-
+    } else {
         sfr::rockblock::ready_status = false;
-        return;
-    }
-
-    // Not in low-power mode; report type cycle order: normal report, IMU report, camera report
-    switch (static_cast<report_type>(sfr::rockblock::downlink_report_type.get())) {
-    case report_type::normal_report:
-        if (sfr::imu::report_ready) {
-            switch_report_type_to(report_type::imu_report);
-            return;
-        }
-
-        if (sfr::camera::report_ready) {
-            switch_report_type_to(report_type::camera_report);
-            return;
-        }
-
-        if (millis() - sfr::rockblock::last_downlink >= sfr::rockblock::downlink_period) {
-            switch_report_type_to(report_type::normal_report);
-            return;
-        }
-
-        // None of the reports are ready
-        sfr::rockblock::ready_status = false;
-        return;
-    case report_type::imu_report:
-        if (sfr::camera::report_ready) {
-            switch_report_type_to(report_type::camera_report);
-            return;
-        }
-
-        if (millis() - sfr::rockblock::last_downlink >= sfr::rockblock::downlink_period) {
-            switch_report_type_to(report_type::normal_report);
-            return;
-        }
-
-        if (sfr::imu::report_ready) {
-            switch_report_type_to(report_type::imu_report);
-            return;
-        }
-
-        // None of the reports are ready
-        sfr::rockblock::ready_status = false;
-        return;
-    case report_type::camera_report:
-        if (millis() - sfr::rockblock::last_downlink >= sfr::rockblock::downlink_period) {
-            switch_report_type_to(report_type::normal_report);
-            return;
-        }
-
-        if (sfr::imu::report_ready) {
-            switch_report_type_to(report_type::imu_report);
-            return;
-        }
-
-        if (sfr::camera::report_ready) {
-            switch_report_type_to(report_type::camera_report);
-            return;
-        }
-
-        // None of the reports are ready
-        sfr::rockblock::ready_status = false;
-        return;
     }
 }

--- a/src/Monitors/RockblockReportMonitor.cpp
+++ b/src/Monitors/RockblockReportMonitor.cpp
@@ -18,10 +18,13 @@ void RockblockReportMonitor::execute()
 
     switch (static_cast<report_type>(sfr::rockblock::downlink_report_type.get())) {
     case report_type::camera_report:
-        sfr::rockblock::downlink_report.clear();
-        for (auto &data : sfr::rockblock::camera_report) {
-            sfr::rockblock::downlink_report.push_back(data);
+        if (last_report_type != report_type::camera_report) {
+            sfr::rockblock::downlink_report.clear();
+            for (auto &data : sfr::rockblock::camera_report) {
+                sfr::rockblock::downlink_report.push_back(data);
+            }
         }
+        last_report_type = report_type::camera_report;
         return;
 
     case report_type::normal_report:
@@ -29,13 +32,17 @@ void RockblockReportMonitor::execute()
         for (auto &data : sfr::rockblock::normal_report) {
             sfr::rockblock::downlink_report.push_back(data);
         }
+        last_report_type = report_type::normal_report;
         return;
 
     case report_type::imu_report:
-        sfr::rockblock::downlink_report.clear();
-        for (auto &data : sfr::rockblock::imu_report) {
-            sfr::rockblock::downlink_report.push_back(data);
+        if (last_report_type != report_type::imu_report) {
+            sfr::rockblock::downlink_report.clear();
+            for (auto &data : sfr::rockblock::imu_report) {
+                sfr::rockblock::downlink_report.push_back(data);
+            }
         }
+        last_report_type = report_type::imu_report;
         return;
     }
 }
@@ -48,10 +55,10 @@ void RockblockReportMonitor::switch_report_type_to(report_type downlink_report_t
 
 void RockblockReportMonitor::schedule_report()
 {
-
-    // Check if in a low-power mode; if so, only enable normal report downlink
-    if (millis() - sfr::rockblock::last_downlink >= sfr::rockblock::downlink_period) {
+    if (!sfr::rockblock::sleep_mode && millis() - sfr::rockblock::last_downlink >= sfr::rockblock::downlink_period) {
+        // Check if in a low-power mode
         if (sfr::mission::current_mode->get_type() == mode_type::LP) {
+            // In low-power mode; only enable normal report downlinks
             sfr::rockblock::downlink_report_type = (uint16_t)report_type::normal_report;
             sfr::rockblock::ready_status = true;
             return;

--- a/src/Monitors/RockblockReportMonitor.hpp
+++ b/src/Monitors/RockblockReportMonitor.hpp
@@ -12,7 +12,6 @@ public:
 private:
     void switch_report_type_to(report_type downlink_report_type);
     void schedule_report();
-    report_type last_report_type;
 };
 
 #endif

--- a/src/Monitors/RockblockReportMonitor.hpp
+++ b/src/Monitors/RockblockReportMonitor.hpp
@@ -12,6 +12,7 @@ public:
 private:
     void switch_report_type_to(report_type downlink_report_type);
     void schedule_report();
+    report_type last_report_type;
 };
 
 #endif


### PR DESCRIPTION
# Report Rotation

### Summary of changes
- Cleaned report cycling logic
- Added check so that report cycling only happens during a transmit mode.

### Testing
Ran deployment sequence on FlatSat and monitored RockBLOCK reports to see that they were properly being cycled.

### SFR Changes
None