### PR TITLE
Turn on IMU during Boot and AliveSignal

### DIFF
--- a/src/MissionMode.cpp
+++ b/src/MissionMode.cpp
@@ -5,7 +5,7 @@ void boot_initialization()
 {
     sfr::rockblock::sleep_mode = true;
     sfr::acs::off = true;
-    sfr::imu::turn_off = true;
+    sfr::imu::turn_on = true;
 }
 
 void Boot::transition_to()
@@ -22,6 +22,8 @@ void Boot::dispatch()
 void AliveSignal::transition_to()
 {
     transmit_mode_settings(false);
+    sfr::imu::turn_off = false; // Calling after transmit_mode_settings to overwrite sfr::imu::turn_off
+    sfr::imu::turn_on = true; 
     sfr::rockblock::ready_status = true;
 }
 void AliveSignal::dispatch()

--- a/src/MissionMode.cpp
+++ b/src/MissionMode.cpp
@@ -23,7 +23,7 @@ void AliveSignal::transition_to()
 {
     transmit_mode_settings(false);
     sfr::imu::turn_off = false; // Calling after transmit_mode_settings to overwrite sfr::imu::turn_off
-    sfr::imu::turn_on = true; 
+    sfr::imu::turn_on = true;
     sfr::rockblock::ready_status = true;
 }
 void AliveSignal::dispatch()


### PR DESCRIPTION
# Turn on IMU during Boot and AliveSignal

It will be helpful to know initial conditions before entering Detumble and Spin.