### PR TITLE
Timeout from camera failure

### DIFF
--- a/src/Control Tasks/CameraControlTask.cpp
+++ b/src/Control Tasks/CameraControlTask.cpp
@@ -9,6 +9,7 @@ void CameraControlTask::execute()
 {
     // handle latent turn on / turn off variables
     if (sfr::camera::turn_off == true && sfr::camera::powered == false) {
+        sfr::camera::failed_times = 0;
         sfr::camera::turn_off = false;
     }
     if (sfr::camera::turn_on == true && sfr::camera::powered == true) {
@@ -54,6 +55,7 @@ void CameraControlTask::execute()
         pinMode(constants::camera::tx, OUTPUT);
         Pins::setPinState(constants::camera::rx, LOW);
         Pins::setPinState(constants::camera::tx, LOW);
+        sfr::camera::failed_times = 0;
         sfr::camera::powered = false;
         sfr::camera::turn_off = false;
         sfr::camera::init_mode = (uint16_t)sensor_init_mode_type::in_progress;

--- a/src/Control Tasks/CameraControlTask.cpp
+++ b/src/Control Tasks/CameraControlTask.cpp
@@ -35,7 +35,6 @@ void CameraControlTask::execute()
             transition_to_normal();
         } else if (sfr::camera::init_mode == (uint16_t)sensor_init_mode_type::failed) {
             if (sfr::camera::failed_times == sfr::camera::failed_limit) {
-                sfr::camera::failed_times = 0; // reset
                 transition_to_abnormal_init();
             } else {
                 sfr::camera::failed_times = sfr::camera::failed_times + 1;

--- a/src/MissionMode.cpp
+++ b/src/MissionMode.cpp
@@ -234,7 +234,7 @@ void BootCamera::transition_to()
 
 void BootCamera::dispatch()
 {
-    if (sfr::camera::init_mode == (uint16_t)sensor_init_mode_type::complete || sfr::camera::failed_times > sfr::camera::failed_limit) {
+    if (sfr::camera::init_mode == (uint16_t)sensor_init_mode_type::complete || sfr::camera::failed_times >= sfr::camera::failed_limit) {
         sfr::mission::current_mode = sfr::mission::mandatoryBurns;
     }
 }


### PR DESCRIPTION
# Timeout from camera failure

### Summary of changes
- Fixed tracking of failed camera inits to dispatch Mandatory Burns after 5 failed attempts

### Testing
Tested on flatsat, following two failed deployment tests with an unplugged camera

### Documentation Evidence
Changes are self-evident