### PR TITLE
IMU Failed Attempts

### DIFF
--- a/src/MissionMode.cpp
+++ b/src/MissionMode.cpp
@@ -49,7 +49,7 @@ void DetumbleSpin::transition_to()
 }
 void DetumbleSpin::dispatch()
 {
-    if (sfr::imu::failed_times > sfr::imu::failed_limit) {
+    if (sfr::imu::failed_times >= sfr::imu::failed_limit) {
         sfr::mission::current_mode = sfr::mission::normal;
         sfr::acs::mode = (uint8_t)acs_mode_type::point;
     }

--- a/src/Monitors/IMUMonitor.cpp
+++ b/src/Monitors/IMUMonitor.cpp
@@ -33,6 +33,7 @@ void IMUMonitor::execute()
     // handle latent turn on / turn off variables
     if (sfr::imu::turn_off == true && sfr::imu::powered == false) {
         sfr::imu::turn_off = false;
+        sfr::imu::failed_times = 0;
     }
     if (sfr::imu::turn_on == true && sfr::imu::powered == true) {
         sfr::imu::turn_on = false;
@@ -49,7 +50,6 @@ void IMUMonitor::execute()
             sfr::imu::powered = true;
         } else {
             if (sfr::imu::failed_times == sfr::imu::failed_limit) {
-                sfr::imu::failed_times = 0; // reset
                 transition_to_abnormal_init();
             } else {
                 sfr::imu::failed_times = sfr::imu::failed_times + 1;


### PR DESCRIPTION
# IMU Failed Attempts

### Summary of changes
Only reset IMU failed attempts when turning IMU off. Change Detumble Spin exit conditions to exit when the number of IMU failed attempts has reached the maximum, not just exceeded it.


### Testing
Tested on Flatsat with IMU unplugged and plugged in.

