### PR TITLE
Imu transition

### DIFF
--- a/src/MissionMode.cpp
+++ b/src/MissionMode.cpp
@@ -215,9 +215,9 @@ void BootIMU::transition_to()
 }
 void BootIMU::dispatch()
 {
-    // sfr::mission::current_mode = sfr::mission::bootImu;
-    // this is where we need to do the 20 seconds
-    if (((sfr::imu::init_mode == (uint16_t)sensor_init_mode_type::complete) && ((millis() - sfr::imu::imu_boot_collection_start_time) >= constants::imu::boot_IMU_min_run_time)) || sfr::imu::failed_times >= sfr::camera::failed_limit) {
+    // Once the IMU is initialized and 20 seconds have passed transition.
+    // OR If the failed tiems exceeds the limit transition
+    if (((sfr::imu::init_mode == (uint16_t)sensor_init_mode_type::complete) && ((millis() - sfr::imu::imu_boot_collection_start_time) >= constants::imu::boot_IMU_min_run_time)) || sfr::imu::failed_times >= sfr::imu::failed_limit) {
         sfr::mission::current_mode = sfr::mission::bootCamera;
         // reset failed times once we transition
         sfr::imu::failed_times = 0;

--- a/src/MissionMode.cpp
+++ b/src/MissionMode.cpp
@@ -52,7 +52,6 @@ void DetumbleSpin::dispatch()
     if (sfr::imu::failed_times >= sfr::imu::failed_limit) {
         sfr::mission::current_mode = sfr::mission::normal;
         sfr::acs::mode = (uint8_t)acs_mode_type::point;
-        sfr::imu::failed_times = 0;
     }
     exit_detumble_phase(sfr::mission::normal);
 }

--- a/src/MissionMode.cpp
+++ b/src/MissionMode.cpp
@@ -52,6 +52,7 @@ void DetumbleSpin::dispatch()
     if (sfr::imu::failed_times >= sfr::imu::failed_limit) {
         sfr::mission::current_mode = sfr::mission::normal;
         sfr::acs::mode = (uint8_t)acs_mode_type::point;
+        sfr::imu::failed_times = 0;
     }
     exit_detumble_phase(sfr::mission::normal);
 }


### PR DESCRIPTION
# IMU Transition

### Summary of changes
-  Fixed the transition from BootIMU to BootCamera. 
- Reset the failed times in DetubleSpin

### Testing
Testing will be done on a FlatSat unplugging the IMU and ensuring it transitions to BootCamera after 5 failed attempts.
