### PR TITLE
Modify how decimal SFRFields are handled

### DIFF
--- a/src/MissionMode.cpp
+++ b/src/MissionMode.cpp
@@ -342,7 +342,7 @@ void enter_lp(MissionMode *lp_mode)
 {
     float voltage;
 
-    if (!sfr::battery::voltage_average->is_valid() || (sfr::battery::voltage_average->get_value(&voltage) && voltage <= sfr::battery::min_battery)) {
+    if (!sfr::battery::voltage_average->is_valid() || (sfr::battery::voltage_average->get_value(&voltage) && voltage <= sfr::battery::min_battery.get_float())) {
         sfr::mission::current_mode = lp_mode;
     }
 }
@@ -362,7 +362,7 @@ void exit_lp(MissionMode *reg_mode)
 
     Serial.println(sfr::battery::voltage_average->get_value(&voltage));
 
-    if (sfr::battery::voltage_average->get_value(&voltage) && voltage > sfr::battery::acceptable_battery) {
+    if (sfr::battery::voltage_average->get_value(&voltage) && voltage > sfr::battery::acceptable_battery.get_float()) {
         Serial.println(voltage);
         sfr::mission::current_mode = reg_mode;
     }
@@ -383,7 +383,7 @@ void enter_lp_insun()
 
     if (!sfr::battery::voltage_average->is_valid()) {
         sfr::mission::current_mode = sfr::mission::voltageFailureInSun;
-    } else if (sfr::battery::voltage_average->get_value(&voltage) && voltage <= sfr::battery::min_battery) {
+    } else if (sfr::battery::voltage_average->get_value(&voltage) && voltage <= sfr::battery::min_battery.get_float()) {
         sfr::mission::current_mode = sfr::mission::lowPowerInSun;
     }
 }

--- a/src/SFRField.hpp
+++ b/src/SFRField.hpp
@@ -76,25 +76,25 @@ public:
 
     SFRField(float default_val, float min, float max, int opcode_val, float resolution)
     {
-        value = default_val * resolution;
+        value = default_val;
         this->min = min;
         this->max = max;
         opcode = opcode_val;
         this->resolution = resolution;
         restore = false;
-        T initial = default_val * resolution;
+        T initial = default_val;
         SFRInterface::opcode_lookup[opcode_val] = this;
     }
 
     SFRField(float default_val, int opcode_val, float resolution)
     {
-        value = default_val * resolution;
+        value = default_val;
         min = std::numeric_limits<T>::min();
         max = std::numeric_limits<T>::max();
         opcode = opcode_val;
         this->resolution = resolution;
         restore = false;
-        T initial = default_val * resolution;
+        T initial = default_val;
         SFRInterface::opcode_lookup[opcode_val] = this;
     }
 

--- a/src/sfr.cpp
+++ b/src/sfr.cpp
@@ -13,11 +13,11 @@ namespace sfr {
     namespace detumble {
         // OP Codes 1500
         // TODO actual default values
-        SFRField<uint8_t> min_stable_gyro_z = SFRField<uint8_t>((1 / constants::imu::sfr_resolution), 0x1500, constants::imu::sfr_resolution);
-        SFRField<uint8_t> max_stable_gyro_x = SFRField<uint8_t>((.2 / constants::imu::sfr_resolution), 0x1501, constants::imu::sfr_resolution);
-        SFRField<uint8_t> max_stable_gyro_y = SFRField<uint8_t>((.2 / constants::imu::sfr_resolution), 0x1502, constants::imu::sfr_resolution);
-        SFRField<uint8_t> min_unstable_gyro_x = SFRField<uint8_t>((.7 / constants::imu::sfr_resolution), 0x1503, constants::imu::sfr_resolution);
-        SFRField<uint8_t> min_unstable_gyro_y = SFRField<uint8_t>((.7 / constants::imu::sfr_resolution), 0x1504, constants::imu::sfr_resolution);
+        SFRField<uint8_t> min_stable_gyro_z = SFRField<uint8_t>((1 * constants::imu::sfr_resolution), 0x1500, constants::imu::sfr_resolution);
+        SFRField<uint8_t> max_stable_gyro_x = SFRField<uint8_t>((0.2 * constants::imu::sfr_resolution), 0x1501, constants::imu::sfr_resolution);
+        SFRField<uint8_t> max_stable_gyro_y = SFRField<uint8_t>((0.2 * constants::imu::sfr_resolution), 0x1502, constants::imu::sfr_resolution);
+        SFRField<uint8_t> min_unstable_gyro_x = SFRField<uint8_t>((0.7 * constants::imu::sfr_resolution), 0x1503, constants::imu::sfr_resolution);
+        SFRField<uint8_t> min_unstable_gyro_y = SFRField<uint8_t>((0.7 * constants::imu::sfr_resolution), 0x1504, constants::imu::sfr_resolution);
         // END TODO
     } // namespace detumble
     namespace aliveSignal {
@@ -241,8 +241,8 @@ namespace sfr {
     } // namespace acs
     namespace battery {
         // OP Codes 2600
-        SFRField<uint32_t> acceptable_battery = SFRField<uint32_t>((3.9 / constants::battery::sfr_resolution), 0x2600, constants::battery::sfr_resolution);
-        SFRField<uint32_t> min_battery = SFRField<uint32_t>((3.75 / constants::battery::sfr_resolution), 0x2601, constants::battery::sfr_resolution);
+        SFRField<uint32_t> acceptable_battery = SFRField<uint32_t>((3.9 * constants::battery::sfr_resolution), 0x2600, constants::battery::sfr_resolution);
+        SFRField<uint32_t> min_battery = SFRField<uint32_t>((3.75 * constants::battery::sfr_resolution), 0x2601, constants::battery::sfr_resolution);
 
         SensorReading *voltage_value = new SensorReading(fault_groups::power_faults::voltage_value, 1, constants::battery::min_voltage, constants::battery::max_voltage);
         SensorReading *voltage_average = new SensorReading(fault_groups::power_faults::voltage_average, 300, constants::battery::min_voltage, constants::battery::max_voltage);


### PR DESCRIPTION
# SFRField Decimal Handling

### Summary of changes
-  Modify how decimal SFRFields are handled
- Made sure min_battery and acceptable_battery call get_float() in the correct place

Example:
Want to set min_battery to 3.65. 
SFRField value is actually going to be 365.
Use get_float to return 3.65.
Regular get() and object calls will return 365.


If it applies, take a chance to describe offshoot work or TODOs that are a part of your PR.

### Testing
Ran on teensy, but not flatsat.