### PR TITLE
Report prints

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -27,7 +27,7 @@ framework = arduino
 upload_protocol = teensy-cli
 test_build_src = true
 board_build.f_cpu = 24000000L
-build_flags = -D VERBOSE -D ACS_SIM -D VERBOSE_RB -D TEENSY_OPT_SMALLEST_CODE
+build_flags = -D ACS_SIM -D VERBOSE -D TEENSY_OPT_SMALLEST_CODE
 lib_ldf_mode = deep
 monitor_filters = default, log2file
 

--- a/src/Control Tasks/CameraControlTask.cpp
+++ b/src/Control Tasks/CameraControlTask.cpp
@@ -88,19 +88,9 @@ void CameraControlTask::execute()
         for (int i = 0; i < bytesToRead; i++) {
             if (buffer[i] < 16) {
                 imgFile.print(0, HEX);
-#ifdef VERBOSE_CAM
-                Serial.print(0, HEX);
-#endif
             }
             imgFile.print(buffer[i], HEX);
-#ifdef VERBOSE_CAM
-            Serial.print(buffer[i], HEX);
-#endif
         }
-
-#ifdef VERBOSE_CAM
-        Serial.println("");
-#endif
 
         jpglen -= bytesToRead;
         imgFile.close();

--- a/src/Control Tasks/RockblockControlTask.cpp
+++ b/src/Control Tasks/RockblockControlTask.cpp
@@ -232,18 +232,18 @@ void RockblockControlTask::dispatch_send_message()
     case report_type::camera_report: {
         Serial.println("Camera Report Downlinking");
         Serial.print("Start Flag: ");
-        print_hex(&sfr::rockblock::downlink_report[0], false);
+        // print_hex(&sfr::rockblock::downlink_report[0], false);
 
         Serial.print("Serial Number: ");
-        print_hex(&sfr::rockblock::downlink_report[1], false);
+        // print_hex(&sfr::rockblock::downlink_report[1], false);
 
         Serial.print("Fragment Number: ");
         uint8_t temp_array[] = {sfr::rockblock::downlink_report[2], sfr::rockblock::downlink_report[3], sfr::rockblock::downlink_report[4], sfr::rockblock::downlink_report[5]};
-        print_hex(temp_array, false);
+        // print_hex(temp_array, false);
 
         Serial.print("Image: ");
         for (int i = 6; i < sfr::rockblock::downlink_report.size(); i++) {
-            print_hex(&sfr::rockblock::downlink_report[i], true);
+            // print_hex(&sfr::rockblock::downlink_report[i], true);
         }
         Serial.println();
         break;
@@ -251,37 +251,163 @@ void RockblockControlTask::dispatch_send_message()
     case report_type::imu_report:
         Serial.println("IMU Report Downlinking");
         Serial.print("Start Flag: ");
-        print_hex(&sfr::rockblock::downlink_report[0], false);
+        // print_hex(&sfr::rockblock::downlink_report[0], false);
 
         Serial.print("Fragment Number: ");
-        print_hex(&sfr::rockblock::downlink_report[1], false);
+        // print_hex(&sfr::rockblock::downlink_report[1], false);
 
         for (int i = 2; i < sfr::rockblock::downlink_report.size() - 2; i = i + 2) {
             Serial.print("Gyro X: ");
-            print_hex(serialize(sfr::rockblock::downlink_report[i], sfr::imu::gyro_x_value->get_min(), sfr::imu::gyro_x_value->get_max()), false);
+            // print_hex(&sfr::rockblock::downlink_report[i], true);
+            // print_hex(deserialize(sfr::rockblock::downlink_report[i], sfr::imu::gyro_x_value->get_min(), sfr::imu::gyro_x_value->get_max()), true);
             Serial.print("Gyro Y: ");
-            print_hex(serialize(sfr::rockblock::downlink_report[i + 1], sfr::imu::gyro_y_value->get_min(), sfr::imu::gyro_y_value->get_max()), false);
+            // print_hex(&sfr::rockblock::downlink_report[i + 1], true);
+            // print_hex(deserialize(sfr::rockblock::downlink_report[i + 1], sfr::imu::gyro_y_value->get_min(), sfr::imu::gyro_y_value->get_max()), true);
             Serial.print("Gyro Z: ");
-            print_hex(serialize(sfr::rockblock::downlink_report[i + 2], sfr::imu::gyro_z_value->get_min(), sfr::imu::gyro_z_value->get_max()), false);
+            // print_hex(&sfr::rockblock::downlink_report[i + 2], true);
+            // print_hex(deserialize(sfr::rockblock::downlink_report[i + 2], sfr::imu::gyro_z_value->get_min(), sfr::imu::gyro_z_value->get_max()), true);
         }
 
         Serial.print("End Flag 1: ");
-        print_hex(&sfr::rockblock::downlink_report[sfr::rockblock::downlink_report.size() - 2], false);
+        // print_hex(&sfr::rockblock::downlink_report[sfr::rockblock::downlink_report.size() - 2], false);
 
         Serial.print("End Flag 2: ");
-        print_hex(&sfr::rockblock::downlink_report[sfr::rockblock::downlink_report.size() - 1], false);
+        // print_hex(&sfr::rockblock::downlink_report[sfr::rockblock::downlink_report.size() - 1], false);
         break;
     case report_type::normal_report:
+        Serial.println("==========================================================================");
         Serial.println("Normal Report Downlinking");
-        Serial.print("Start Flag: ");
-        print_hex(&sfr::rockblock::downlink_report[0], false);
+        Serial.println("==========================================================================");
+        Serial.println("Item Name            || Raw Hex         || Deserialized & Decimal         ");
+        Serial.println("--------------------------------------------------------------------------");
 
-        Serial.print("sfr::mission::boot_time_mins: ");
-        print_hex(&sfr::rockblock::downlink_report[1], false);
+        Serial.print("Start Flag->");
+        print_hex(sfr::rockblock::downlink_report[0]);
+        Serial.print("->");
+        Serial.println(sfr::rockblock::downlink_report[0]);
+        Serial.println("--------------------------------------------------------------------------");
 
-        Serial.print("sfr::mission::boot_time_mins: ");
-        print_hex(&sfr::rockblock::downlink_report[1], false);
+        Serial.print("sfr::mission::boot_time_mins->");
+        print_SFRField(1, 0x1802);
 
+        Serial.print("sfr::burnwire::burn_time->");
+        print_SFRField(2, 0x1905);
+
+        Serial.print("sfr::burnwire::armed_time->");
+        print_SFRField(3, 0x1906);
+
+        Serial.print("sfr::rockblock::lp_downlink_period->");
+        print_SFRField(4, 0x2109);
+
+        Serial.print("sfr::rockblock::transmit_downlink_period->");
+        print_SFRField(5, 0x2110);
+
+        Serial.print("sfr::acs::mode->");
+        print_SFRField(6, 0x2501);
+
+        Serial.print("sfr::acs::Id_index->");
+        print_SFRField(7, 0x2505);
+
+        Serial.print("sfr::acs::Kd_index->");
+        print_SFRField(8, 0x2506);
+
+        Serial.print("sfr::acs::Kp_index->");
+        print_SFRField(9, 0x2507);
+
+        Serial.print("sfr::acs::c_index->");
+        print_SFRField(10, 0x2508);
+
+        Serial.print("sfr::eeprom::boot_counter->");
+        print_SFRField(11, 0x2805);
+
+        Serial.print("sfr::eeprom::dynamic_data_addr->");
+        print_SFRField(12, 0x2806);
+
+        Serial.print("sfr::eeprom::sfr_data_addr->");
+        print_SFRField(13, 0x2807);
+
+        Serial.print("sfr::eeprom::time_alive->");
+        print_SFRField(14, 0x2808);
+
+        Serial.print("sfr::eeprom::dynamic_data_age->");
+        print_SFRField(15, 0x2809);
+
+        Serial.print("sfr::eeprom::sfr_data_age->");
+        print_SFRField(16, 0x2810);
+
+        Serial.print("sfr::acs::on_time->");
+        print_SFRField(17, 0x2504);
+
+        Serial.print("sfr::rockblock::on_time->");
+        print_SFRField(18, 0x2111);
+
+        Serial.print("sfr_packed_bools: ");
+        Serial.print("sfr::photoresistor::covered: ");
+        Serial.println(sfr::rockblock::downlink_report[19] & (1 << 0));
+        Serial.print("sfr::mission::possible_uncovered: ");
+        Serial.println(sfr::rockblock::downlink_report[19] & (1 << 1));
+        Serial.print("sfr::camera::powered: ");
+        Serial.println(sfr::rockblock::downlink_report[19] & (1 << 2));
+        Serial.print("sfr::mission::deployed: ");
+        Serial.println(sfr::rockblock::downlink_report[19] & (1 << 3));
+        Serial.print("sfr::rockblock::waiting_command: ");
+        Serial.println(sfr::rockblock::downlink_report[19] & (1 << 4));
+        Serial.print("sfr::temperature::in_sun: ");
+        Serial.println(sfr::rockblock::downlink_report[19] & (1 << 5));
+        Serial.print("sfr::current::in_sun: ");
+        Serial.println(sfr::rockblock::downlink_report[19] & (1 << 6));
+        Serial.print("sfr::button::pressed: ");
+        Serial.println(sfr::rockblock::downlink_report[19] & (1 << 7));
+
+        Serial.print("sfr::photoresistor::light_val_average_standby: ");
+        // print_hex(&sfr::rockblock::downlink_report[20], true);
+        // print_hex(deserialize(sfr::rockblock::downlink_report[20], sfr::photoresistor::light_val_average_standby->get_min(), sfr::photoresistor::light_val_average_standby->get_max()), true);
+
+        Serial.print("sfr::imu::mag_x_average: ");
+        // print_hex(&sfr::rockblock::downlink_report[21], true);
+        // print_hex(deserialize(sfr::rockblock::downlink_report[21], sfr::imu::mag_x_average->get_min(), sfr::imu::mag_x_average->get_max()), true);
+
+        Serial.print("sfr::imu::mag_y_average: ");
+        // print_hex(&sfr::rockblock::downlink_report[22], true);
+        // print_hex(deserialize(sfr::rockblock::downlink_report[22], sfr::imu::mag_y_average->get_min(), sfr::imu::mag_y_average->get_max()), true);
+
+        Serial.print("sfr::imu::mag_z_average: ");
+        // print_hex(&sfr::rockblock::downlink_report[23], true);
+        // print_hex(deserialize(sfr::rockblock::downlink_report[23], sfr::imu::mag_z_average->get_min(), sfr::imu::mag_z_average->get_max()), true);
+
+        Serial.print("sfr::imu::gyro_x_average: ");
+        // print_hex(&sfr::rockblock::downlink_report[24], true);
+        // print_hex(deserialize(sfr::rockblock::downlink_report[24], sfr::imu::gyro_x_average->get_min(), sfr::imu::gyro_x_average->get_max()), true);
+
+        Serial.print("sfr::imu::gyro_y_average: ");
+        // print_hex(&sfr::rockblock::downlink_report[25], true);
+        // print_hex(deserialize(sfr::rockblock::downlink_report[25], sfr::imu::gyro_y_average->get_min(), sfr::imu::gyro_y_average->get_max()), true);
+
+        Serial.print("sfr::imu::gyro_z_average: ");
+        // print_hex(&sfr::rockblock::downlink_report[26], true);
+        // print_hex(deserialize(sfr::rockblock::downlink_report[26], sfr::imu::gyro_z_average->get_min(), sfr::imu::gyro_z_average->get_max()), true);
+
+        Serial.print("sfr::temperature::temp_c_value: ");
+        // print_hex(&sfr::rockblock::downlink_report[27], true);
+        // print_hex(deserialize(sfr::rockblock::downlink_report[27], sfr::temperature::temp_c_value->get_min(), sfr::temperature::temp_c_value->get_max()), true);
+
+        Serial.print("sfr::temperature::temp_c_average: ");
+        // print_hex(&sfr::rockblock::downlink_report[28], true);
+        // print_hex(deserialize(sfr::rockblock::downlink_report[28], sfr::temperature::temp_c_average->get_min(), sfr::temperature::temp_c_average->get_max()), true);
+
+        Serial.print("sfr::current::solar_current_average: ");
+        // print_hex(&sfr::rockblock::downlink_report[29], true);
+        // print_hex(deserialize(sfr::rockblock::downlink_report[29], sfr::current::solar_current_average->get_min(), sfr::current::solar_current_average->get_max()), true);
+
+        Serial.print("sfr::battery::voltage_value: ");
+        // print_hex(&sfr::rockblock::downlink_report[30], true);
+        // print_hex(deserialize(sfr::rockblock::downlink_report[30], sfr::battery::voltage_value->get_min(), sfr::battery::voltage_value->get_max()), true);
+
+        Serial.print("sfr::battery::voltage_average: ");
+        // print_hex(&sfr::rockblock::downlink_report[31], true);
+        // print_hex(deserialize(sfr::rockblock::downlink_report[31], sfr::battery::voltage_average->get_min(), sfr::battery::voltage_average->get_max()), true);
+
+        delay(1000);
         break;
     }
 
@@ -652,25 +778,34 @@ void RockblockControlTask::get_valid_signal(rockblock_mode_type good_signal, roc
     }
 }
 
-void RockblockControlTask::print_hex(uint8_t *hex_num, bool raw)
+void RockblockControlTask::print_hex(uint8_t hex_num)
 {
-    for (size_t i = 0; i < sizeof(hex_num) / sizeof(uint8_t); i++) {
-        if (hex_num[i] < 16) {
-            Serial.print(0);
-        }
-        Serial.print(hex_num[i], HEX);
+    if (hex_num < 16) {
+        Serial.print(0);
     }
-
-    if (!raw) {
-        Serial.print(" -> ");
-        Serial.print(*(int *)hex_num);
-    }
+    Serial.print(hex_num, HEX);
 }
 
-uint8_t *RockblockControlTask::serialize(float value, float min, float max)
+float RockblockControlTask::deserialize(float value, float min, float max)
 {
     if ((max - min) == 0) {
         return 0;
     }
-    return (uint8_t *)(uint8_t)(map(value, 0, 255, min, max));
+    return map(value, 0, 255, min, max);
 }
+
+float RockblockControlTask::deserialize(float value, int opcode)
+{
+    SFRInterface *valueObj = SFRInterface::opcode_lookup[opcode];
+    return deserialize(value, valueObj->getMin(), valueObj->getMax());
+}
+
+void RockblockControlTask::print_SFRField(int i, int opcode)
+{
+    print_hex(sfr::rockblock::downlink_report[i]);
+    Serial.print("->");
+    Serial.println(deserialize(sfr::rockblock::downlink_report[i], opcode));
+    Serial.println("--------------------------------------------------------------------------");
+}
+
+

--- a/src/Control Tasks/RockblockControlTask.cpp
+++ b/src/Control Tasks/RockblockControlTask.cpp
@@ -230,55 +230,90 @@ void RockblockControlTask::dispatch_send_message()
 #ifdef VERBOSE
     switch (static_cast<report_type>(sfr::rockblock::downlink_report_type.get())) {
     case report_type::camera_report: {
+        Serial.println("==========================================================================");
         Serial.println("Camera Report Downlinking");
-        Serial.print("Start Flag: ");
-        // print_hex(&sfr::rockblock::downlink_report[0], false);
+        Serial.println("==========================================================================");
+        Serial.println("Item Name            -> Raw Hex         -> Deserialized & Decimal         ");
+        Serial.println("--------------------------------------------------------------------------");
 
-        Serial.print("Serial Number: ");
-        // print_hex(&sfr::rockblock::downlink_report[1], false);
+        Serial.print("Start Flag->");
+        print_hex(sfr::rockblock::downlink_report[0]);
+        Serial.print("->");
+        Serial.println(sfr::rockblock::downlink_report[0]);
+        Serial.println("--------------------------------------------------------------------------");
 
-        Serial.print("Fragment Number: ");
-        uint8_t temp_array[] = {sfr::rockblock::downlink_report[2], sfr::rockblock::downlink_report[3], sfr::rockblock::downlink_report[4], sfr::rockblock::downlink_report[5]};
-        // print_hex(temp_array, false);
+        Serial.print("Serial Number->");
+        print_hex(sfr::rockblock::downlink_report[1]);
+        Serial.print("->");
+        Serial.println(sfr::rockblock::downlink_report[1]);
+        Serial.println("--------------------------------------------------------------------------");
+
+        Serial.print("Fragment Number->");
+        print_hex(sfr::rockblock::downlink_report[2]);
+        print_hex(sfr::rockblock::downlink_report[3]);
+        print_hex(sfr::rockblock::downlink_report[4]);
+        print_hex(sfr::rockblock::downlink_report[5]);
+        Serial.print("->");
+        uint32_t fragment_number = 0;
+        fragment_number = (sfr::rockblock::downlink_report[5] << 24) + (sfr::rockblock::downlink_report[4] << 16) + (sfr::rockblock::downlink_report[3] << 8) + sfr::rockblock::downlink_report[2];
+        Serial.println(fragment_number);
+        Serial.println("--------------------------------------------------------------------------");
 
         Serial.print("Image: ");
         for (int i = 6; i < sfr::rockblock::downlink_report.size(); i++) {
-            // print_hex(&sfr::rockblock::downlink_report[i], true);
+            print_hex(sfr::rockblock::downlink_report[i]);
         }
-        Serial.println();
+        Serial.println("==========================================================================");
         break;
     }
     case report_type::imu_report:
+        Serial.println("==========================================================================");
         Serial.println("IMU Report Downlinking");
-        Serial.print("Start Flag: ");
-        // print_hex(&sfr::rockblock::downlink_report[0], false);
+        Serial.println("==========================================================================");
+        Serial.println("Item Name            -> Raw Hex         -> Deserialized & Decimal         ");
+        Serial.println("--------------------------------------------------------------------------");
+
+        Serial.print("Start Flag->");
+        print_hex(sfr::rockblock::downlink_report[0]);
+        Serial.print("->");
+        Serial.println(sfr::rockblock::downlink_report[0]);
+        Serial.println("--------------------------------------------------------------------------");
 
         Serial.print("Fragment Number: ");
-        // print_hex(&sfr::rockblock::downlink_report[1], false);
+        print_hex(sfr::rockblock::downlink_report[1]);
+        Serial.print("->");
+        Serial.println(sfr::rockblock::downlink_report[1]);
+        Serial.println("--------------------------------------------------------------------------");
 
         for (int i = 2; i < sfr::rockblock::downlink_report.size() - 2; i = i + 2) {
             Serial.print("Gyro X: ");
-            // print_hex(&sfr::rockblock::downlink_report[i], true);
-            // print_hex(deserialize(sfr::rockblock::downlink_report[i], sfr::imu::gyro_x_value->get_min(), sfr::imu::gyro_x_value->get_max()), true);
+            print_SensorReading(i, sfr::imu::gyro_x_value);
+
             Serial.print("Gyro Y: ");
-            // print_hex(&sfr::rockblock::downlink_report[i + 1], true);
-            // print_hex(deserialize(sfr::rockblock::downlink_report[i + 1], sfr::imu::gyro_y_value->get_min(), sfr::imu::gyro_y_value->get_max()), true);
+            print_SensorReading(i + 1, sfr::imu::gyro_y_value);
+
             Serial.print("Gyro Z: ");
-            // print_hex(&sfr::rockblock::downlink_report[i + 2], true);
-            // print_hex(deserialize(sfr::rockblock::downlink_report[i + 2], sfr::imu::gyro_z_value->get_min(), sfr::imu::gyro_z_value->get_max()), true);
+            print_SensorReading(i + 2, sfr::imu::gyro_z_value);
+            Serial.println("--------------------------------------------------------------------------");
         }
 
         Serial.print("End Flag 1: ");
-        // print_hex(&sfr::rockblock::downlink_report[sfr::rockblock::downlink_report.size() - 2], false);
+        print_hex(sfr::rockblock::downlink_report[sfr::rockblock::downlink_report.size() - 2]);
+        Serial.print("->");
+        Serial.println(sfr::rockblock::downlink_report[sfr::rockblock::downlink_report.size() - 2]);
+        Serial.println("--------------------------------------------------------------------------");
 
         Serial.print("End Flag 2: ");
-        // print_hex(&sfr::rockblock::downlink_report[sfr::rockblock::downlink_report.size() - 1], false);
+        print_hex(sfr::rockblock::downlink_report[sfr::rockblock::downlink_report.size() - 1]);
+        Serial.print("->");
+        Serial.println(sfr::rockblock::downlink_report[sfr::rockblock::downlink_report.size() - 1]);
+        Serial.println("==========================================================================");
         break;
     case report_type::normal_report:
         Serial.println("==========================================================================");
         Serial.println("Normal Report Downlinking");
         Serial.println("==========================================================================");
-        Serial.println("Item Name            || Raw Hex         || Deserialized & Decimal         ");
+        Serial.println("Item Name            -> Raw Hex         -> Deserialized & Decimal         ");
         Serial.println("--------------------------------------------------------------------------");
 
         Serial.print("Start Flag->");
@@ -341,79 +376,162 @@ void RockblockControlTask::dispatch_send_message()
         Serial.print("sfr::rockblock::on_time->");
         print_SFRField(18, 0x2111);
 
-        Serial.print("sfr_packed_bools: ");
-        Serial.print("sfr::photoresistor::covered: ");
-        Serial.println(sfr::rockblock::downlink_report[19] & (1 << 0));
-        Serial.print("sfr::mission::possible_uncovered: ");
-        Serial.println(sfr::rockblock::downlink_report[19] & (1 << 1));
-        Serial.print("sfr::camera::powered: ");
-        Serial.println(sfr::rockblock::downlink_report[19] & (1 << 2));
-        Serial.print("sfr::mission::deployed: ");
-        Serial.println(sfr::rockblock::downlink_report[19] & (1 << 3));
-        Serial.print("sfr::rockblock::waiting_command: ");
-        Serial.println(sfr::rockblock::downlink_report[19] & (1 << 4));
-        Serial.print("sfr::temperature::in_sun: ");
-        Serial.println(sfr::rockblock::downlink_report[19] & (1 << 5));
-        Serial.print("sfr::current::in_sun: ");
-        Serial.println(sfr::rockblock::downlink_report[19] & (1 << 6));
-        Serial.print("sfr::button::pressed: ");
-        Serial.println(sfr::rockblock::downlink_report[19] & (1 << 7));
+        Serial.print("sfr::photoresistor::covered->");
+        Serial.println((bool)(sfr::rockblock::downlink_report[19] & (1 << 0)));
+        Serial.print("sfr::mission::possible_uncovered->");
+        Serial.println((bool)(sfr::rockblock::downlink_report[19] & (1 << 1)));
+        Serial.print("sfr::camera::powered->");
+        Serial.println((bool)(sfr::rockblock::downlink_report[19] & (1 << 2)));
+        Serial.print("sfr::mission::deployed->");
+        Serial.println((bool)(sfr::rockblock::downlink_report[19] & (1 << 3)));
+        Serial.print("sfr::rockblock::waiting_command->");
+        Serial.println((bool)(sfr::rockblock::downlink_report[19] & (1 << 4)));
+        Serial.print("sfr::temperature::in_sun->");
+        Serial.println((bool)(sfr::rockblock::downlink_report[19] & (1 << 5)));
+        Serial.print("sfr::current::in_sun->");
+        Serial.println((bool)(sfr::rockblock::downlink_report[19] & (1 << 6)));
+        Serial.print("sfr::button::pressed->");
+        Serial.println((bool)(sfr::rockblock::downlink_report[19] & (1 << 7)));
+        Serial.println("--------------------------------------------------------------------------");
 
-        Serial.print("sfr::photoresistor::light_val_average_standby: ");
-        // print_hex(&sfr::rockblock::downlink_report[20], true);
-        // print_hex(deserialize(sfr::rockblock::downlink_report[20], sfr::photoresistor::light_val_average_standby->get_min(), sfr::photoresistor::light_val_average_standby->get_max()), true);
+        Serial.print("sfr::photoresistor::light_val_average_standby->");
+        print_SensorReading(20, sfr::photoresistor::light_val_average_standby);
 
-        Serial.print("sfr::imu::mag_x_average: ");
-        // print_hex(&sfr::rockblock::downlink_report[21], true);
-        // print_hex(deserialize(sfr::rockblock::downlink_report[21], sfr::imu::mag_x_average->get_min(), sfr::imu::mag_x_average->get_max()), true);
+        Serial.print("sfr::imu::mag_x_average->");
+        print_SensorReading(21, sfr::imu::mag_x_average);
 
-        Serial.print("sfr::imu::mag_y_average: ");
-        // print_hex(&sfr::rockblock::downlink_report[22], true);
-        // print_hex(deserialize(sfr::rockblock::downlink_report[22], sfr::imu::mag_y_average->get_min(), sfr::imu::mag_y_average->get_max()), true);
+        Serial.print("sfr::imu::mag_y_average->");
+        print_SensorReading(22, sfr::imu::mag_y_average);
 
-        Serial.print("sfr::imu::mag_z_average: ");
-        // print_hex(&sfr::rockblock::downlink_report[23], true);
-        // print_hex(deserialize(sfr::rockblock::downlink_report[23], sfr::imu::mag_z_average->get_min(), sfr::imu::mag_z_average->get_max()), true);
+        Serial.print("sfr::imu::mag_z_average->");
+        print_SensorReading(23, sfr::imu::mag_z_average);
 
-        Serial.print("sfr::imu::gyro_x_average: ");
-        // print_hex(&sfr::rockblock::downlink_report[24], true);
-        // print_hex(deserialize(sfr::rockblock::downlink_report[24], sfr::imu::gyro_x_average->get_min(), sfr::imu::gyro_x_average->get_max()), true);
+        Serial.print("sfr::imu::gyro_x_average->");
+        print_SensorReading(24, sfr::imu::gyro_x_average);
 
-        Serial.print("sfr::imu::gyro_y_average: ");
-        // print_hex(&sfr::rockblock::downlink_report[25], true);
-        // print_hex(deserialize(sfr::rockblock::downlink_report[25], sfr::imu::gyro_y_average->get_min(), sfr::imu::gyro_y_average->get_max()), true);
+        Serial.print("sfr::imu::gyro_y_average->");
+        print_SensorReading(25, sfr::imu::gyro_y_average);
 
-        Serial.print("sfr::imu::gyro_z_average: ");
-        // print_hex(&sfr::rockblock::downlink_report[26], true);
-        // print_hex(deserialize(sfr::rockblock::downlink_report[26], sfr::imu::gyro_z_average->get_min(), sfr::imu::gyro_z_average->get_max()), true);
+        Serial.print("sfr::imu::gyro_z_average->");
+        print_SensorReading(26, sfr::imu::gyro_z_average);
 
-        Serial.print("sfr::temperature::temp_c_value: ");
-        // print_hex(&sfr::rockblock::downlink_report[27], true);
-        // print_hex(deserialize(sfr::rockblock::downlink_report[27], sfr::temperature::temp_c_value->get_min(), sfr::temperature::temp_c_value->get_max()), true);
+        Serial.print("sfr::temperature::temp_c_value->");
+        print_SensorReading(27, sfr::temperature::temp_c_value);
 
-        Serial.print("sfr::temperature::temp_c_average: ");
-        // print_hex(&sfr::rockblock::downlink_report[28], true);
-        // print_hex(deserialize(sfr::rockblock::downlink_report[28], sfr::temperature::temp_c_average->get_min(), sfr::temperature::temp_c_average->get_max()), true);
+        Serial.print("sfr::temperature::temp_c_average->");
+        print_SensorReading(28, sfr::temperature::temp_c_average);
 
-        Serial.print("sfr::current::solar_current_average: ");
-        // print_hex(&sfr::rockblock::downlink_report[29], true);
-        // print_hex(deserialize(sfr::rockblock::downlink_report[29], sfr::current::solar_current_average->get_min(), sfr::current::solar_current_average->get_max()), true);
+        Serial.print("sfr::current::solar_current_average->");
+        print_SensorReading(29, sfr::current::solar_current_average);
 
-        Serial.print("sfr::battery::voltage_value: ");
-        // print_hex(&sfr::rockblock::downlink_report[30], true);
-        // print_hex(deserialize(sfr::rockblock::downlink_report[30], sfr::battery::voltage_value->get_min(), sfr::battery::voltage_value->get_max()), true);
+        Serial.print("sfr::battery::voltage_value->");
+        print_SensorReading(30, sfr::battery::voltage_value);
 
-        Serial.print("sfr::battery::voltage_average: ");
-        // print_hex(&sfr::rockblock::downlink_report[31], true);
-        // print_hex(deserialize(sfr::rockblock::downlink_report[31], sfr::battery::voltage_average->get_min(), sfr::battery::voltage_average->get_max()), true);
+        Serial.print("sfr::battery::voltage_average->");
+        print_SensorReading(31, sfr::battery::voltage_average);
 
-        delay(1000);
+        Serial.println("fault_groups::imu_faults::mag_x_average->");
+        print_Fault(32, false);
+        Serial.println("fault_groups::imu_faults::mag_x_value->");
+        print_Fault(32, true);
+
+        Serial.println("fault_groups::imu_faults::mag_y_average->");
+        print_Fault(33, false);
+        Serial.println("fault_groups::imu_faults::mag_y_value->");
+        print_Fault(33, true);
+
+        Serial.println("fault_groups::imu_faults::mag_z_average->");
+        print_Fault(34, false);
+        Serial.println("fault_groups::imu_faults::mag_z_value->");
+        print_Fault(34, true);
+
+        Serial.println("fault_groups::imu_faults::gyro_x_average->");
+        print_Fault(35, false);
+        Serial.println("fault_groups::imu_faults::gyro_x_value->");
+        print_Fault(35, true);
+
+        Serial.println("fault_groups::imu_faults::gyro_y_average->");
+        print_Fault(36, false);
+        Serial.println("fault_groups::imu_faults::gyro_y_value->");
+        print_Fault(36, true);
+
+        Serial.println("fault_groups::imu_faults::gyro_z_average->");
+        print_Fault(37, false);
+        Serial.println("fault_groups::imu_faults::gyro_z_value->");
+        print_Fault(37, true);
+
+        Serial.println("fault_groups::power_faults::temp_c_average->");
+        print_Fault(38, false);
+        Serial.println("fault_groups::power_faults::temp_c_value->");
+        print_Fault(38, true);
+
+        Serial.println("fault_groups::power_faults::voltage_average->");
+        print_Fault(39, false);
+        Serial.println("fault_groups::power_faults::voltage_value->");
+        print_Fault(39, true);
+
+        Serial.println("fault_groups::hardware_faults::button->");
+        print_Fault(40, false);
+        Serial.println("fault_groups::hardware_faults::light_val->");
+        print_Fault(40, true);
+
+        Serial.println("fault_groups::power_faults::solar_current_average->");
+        print_Fault(41, true);
+
+        Serial.print("sfr::eeprom::boot_restarted->");
+        Serial.println((bool)(sfr::rockblock::downlink_report[41] & (1 << 0)));
+        Serial.print("sfr::eeprom::error_mode->");
+        Serial.println((bool)(sfr::rockblock::downlink_report[41] & (1 << 1)));
+        Serial.print("sfr::eeprom::light_switch->");
+        Serial.println((bool)(sfr::rockblock::downlink_report[41] & (1 << 2)));
+        Serial.print("sfr::eeprom::sfr_save_completed->");
+        Serial.println((bool)(sfr::rockblock::downlink_report[41] & (1 << 3)));
+        Serial.println("--------------------------------------------------------------------------");
+
+        Serial.print("Mission Mode History->");
+        print_hex(sfr::rockblock::downlink_report[42]);
+        print_hex(sfr::rockblock::downlink_report[43]);
+        print_hex(sfr::rockblock::downlink_report[44]);
+        print_hex(sfr::rockblock::downlink_report[45]);
+        print_hex(sfr::rockblock::downlink_report[46]);
+        print_hex(sfr::rockblock::downlink_report[47]);
+        print_hex(sfr::rockblock::downlink_report[48]);
+        print_hex(sfr::rockblock::downlink_report[49]);
+        print_hex(sfr::rockblock::downlink_report[50]);
+        print_hex(sfr::rockblock::downlink_report[51]);
+        Serial.println();
+        Serial.println("--------------------------------------------------------------------------");
+
+        Serial.print("Processed Opcodes->");
+        print_hex(sfr::rockblock::downlink_report[52]);
+        print_hex(sfr::rockblock::downlink_report[53]);
+        print_hex(sfr::rockblock::downlink_report[54]);
+        print_hex(sfr::rockblock::downlink_report[55]);
+        print_hex(sfr::rockblock::downlink_report[56]);
+        print_hex(sfr::rockblock::downlink_report[57]);
+        print_hex(sfr::rockblock::downlink_report[58]);
+        print_hex(sfr::rockblock::downlink_report[59]);
+        print_hex(sfr::rockblock::downlink_report[60]);
+        print_hex(sfr::rockblock::downlink_report[61]);
+        print_hex(sfr::rockblock::downlink_report[62]);
+        print_hex(sfr::rockblock::downlink_report[63]);
+        print_hex(sfr::rockblock::downlink_report[64]);
+        print_hex(sfr::rockblock::downlink_report[65]);
+        print_hex(sfr::rockblock::downlink_report[66]);
+        print_hex(sfr::rockblock::downlink_report[67]);
+        print_hex(sfr::rockblock::downlink_report[68]);
+        print_hex(sfr::rockblock::downlink_report[69]);
+        Serial.println();
+        Serial.println("==========================================================================");
         break;
     }
-
+    Serial.print("SENT: ");
 #endif
     for (auto &data : sfr::rockblock::downlink_report) {
         sfr::rockblock::serial.write(data);
+#ifdef VERBOSE
+        print_hex(data);
+#endif
         checksum += (uint16_t)data;
     }
 
@@ -794,18 +912,35 @@ float RockblockControlTask::deserialize(float value, float min, float max)
     return map(value, 0, 255, min, max);
 }
 
-float RockblockControlTask::deserialize(float value, int opcode)
-{
-    SFRInterface *valueObj = SFRInterface::opcode_lookup[opcode];
-    return deserialize(value, valueObj->getMin(), valueObj->getMax());
-}
-
 void RockblockControlTask::print_SFRField(int i, int opcode)
 {
+    SFRInterface *valueObj = SFRInterface::opcode_lookup[opcode];
     print_hex(sfr::rockblock::downlink_report[i]);
     Serial.print("->");
-    Serial.println(deserialize(sfr::rockblock::downlink_report[i], opcode));
+    Serial.println(deserialize(sfr::rockblock::downlink_report[i], valueObj->getMin(), valueObj->getMax()));
     Serial.println("--------------------------------------------------------------------------");
 }
 
+void RockblockControlTask::print_SensorReading(int i, SensorReading *valueObj)
+{
+    print_hex(sfr::rockblock::downlink_report[i]);
+    Serial.print("->");
+    Serial.println(deserialize(sfr::rockblock::downlink_report[i], valueObj->get_min(), valueObj->get_max()));
+    Serial.println("--------------------------------------------------------------------------");
+}
 
+void RockblockControlTask::print_Fault(int i, bool shift)
+{
+    Serial.print("Signaled: ");
+    Serial.println((bool)(sfr::rockblock::downlink_report[i] & (1 << (0 + shift * 4))));
+
+    Serial.print("Suppressed: ");
+    Serial.println((bool)(sfr::rockblock::downlink_report[i] & (1 << (1 + shift * 4))));
+
+    Serial.print("Forced: ");
+    Serial.println((bool)(sfr::rockblock::downlink_report[i] & (1 << (2 + shift * 4))));
+
+    Serial.print("Base: ");
+    Serial.println((bool)(sfr::rockblock::downlink_report[i] & (1 << (3 + shift * 4))));
+    Serial.println("--------------------------------------------------------------------------");
+}

--- a/src/Control Tasks/RockblockControlTask.cpp
+++ b/src/Control Tasks/RockblockControlTask.cpp
@@ -249,10 +249,38 @@ void RockblockControlTask::dispatch_send_message()
         break;
     }
     case report_type::imu_report:
-        Serial.print("IMU Report Downlinking\n");
+        Serial.println("IMU Report Downlinking");
+        Serial.print("Start Flag: ");
+        print_hex(&sfr::rockblock::downlink_report[0], false);
+
+        Serial.print("Fragment Number: ");
+        print_hex(&sfr::rockblock::downlink_report[1], false);
+
+        for (int i = 2; i < sfr::rockblock::downlink_report.size() - 2; i = i + 2) {
+            Serial.print("Gyro X: ");
+            print_hex(serialize(sfr::rockblock::downlink_report[i], sfr::imu::gyro_x_value->get_min(), sfr::imu::gyro_x_value->get_max()), false);
+            Serial.print("Gyro Y: ");
+            print_hex(serialize(sfr::rockblock::downlink_report[i + 1], sfr::imu::gyro_y_value->get_min(), sfr::imu::gyro_y_value->get_max()), false);
+            Serial.print("Gyro Z: ");
+            print_hex(serialize(sfr::rockblock::downlink_report[i + 2], sfr::imu::gyro_z_value->get_min(), sfr::imu::gyro_z_value->get_max()), false);
+        }
+
+        Serial.print("End Flag 1: ");
+        print_hex(&sfr::rockblock::downlink_report[sfr::rockblock::downlink_report.size() - 2], false);
+
+        Serial.print("End Flag 2: ");
+        print_hex(&sfr::rockblock::downlink_report[sfr::rockblock::downlink_report.size() - 1], false);
         break;
     case report_type::normal_report:
-        Serial.print("Normal Report Downlinking\n");
+        Serial.println("Normal Report Downlinking");
+        Serial.print("Start Flag: ");
+        print_hex(&sfr::rockblock::downlink_report[0], false);
+
+        Serial.print("sfr::mission::boot_time_mins: ");
+        print_hex(&sfr::rockblock::downlink_report[1], false);
+
+        Serial.print("sfr::mission::boot_time_mins: ");
+        print_hex(&sfr::rockblock::downlink_report[1], false);
 
         break;
     }
@@ -637,4 +665,12 @@ void RockblockControlTask::print_hex(uint8_t *hex_num, bool raw)
         Serial.print(" -> ");
         Serial.print(*(int *)hex_num);
     }
+}
+
+uint8_t *RockblockControlTask::serialize(float value, float min, float max)
+{
+    if ((max - min) == 0) {
+        return 0;
+    }
+    return (uint8_t *)(uint8_t)(map(value, 0, 255, min, max));
 }

--- a/src/Control Tasks/RockblockControlTask.hpp
+++ b/src/Control Tasks/RockblockControlTask.hpp
@@ -45,8 +45,9 @@ private:
     void print_hex(uint8_t hex_num);
     RockblockCommand *commandFactory(RawRockblockCommand raw);
     float deserialize(float value, float min, float max);
-    float deserialize(float value, int opcode);
     void print_SFRField(int i, int opcode);
+    void print_SensorReading(int i, SensorReading *valueObj);
+    void print_Fault(int i, bool shift);
     uint32_t conseq_reads = 0;
     uint32_t same_mode = 0;
     uint8_t look_ahead1 = -1;

--- a/src/Control Tasks/RockblockControlTask.hpp
+++ b/src/Control Tasks/RockblockControlTask.hpp
@@ -42,9 +42,11 @@ private:
     bool get_OK();
     void get_valid_signal(rockblock_mode_type good_signal, rockblock_mode_type bad_signal);
     void transition_to(rockblock_mode_type new_mode);
-    void print_hex(uint8_t *hex_num, bool raw);
+    void print_hex(uint8_t hex_num);
     RockblockCommand *commandFactory(RawRockblockCommand raw);
-    uint8_t *serialize(float value, float min, float max);
+    float deserialize(float value, float min, float max);
+    float deserialize(float value, int opcode);
+    void print_SFRField(int i, int opcode);
     uint32_t conseq_reads = 0;
     uint32_t same_mode = 0;
     uint8_t look_ahead1 = -1;

--- a/src/Control Tasks/RockblockControlTask.hpp
+++ b/src/Control Tasks/RockblockControlTask.hpp
@@ -44,6 +44,7 @@ private:
     void transition_to(rockblock_mode_type new_mode);
     void print_hex(uint8_t *hex_num, bool raw);
     RockblockCommand *commandFactory(RawRockblockCommand raw);
+    uint8_t *serialize(float value, float min, float max);
     uint32_t conseq_reads = 0;
     uint32_t same_mode = 0;
     uint8_t look_ahead1 = -1;

--- a/src/Control Tasks/RockblockControlTask.hpp
+++ b/src/Control Tasks/RockblockControlTask.hpp
@@ -42,6 +42,7 @@ private:
     bool get_OK();
     void get_valid_signal(rockblock_mode_type good_signal, rockblock_mode_type bad_signal);
     void transition_to(rockblock_mode_type new_mode);
+    void print_hex(uint8_t *hex_num, bool raw);
     RockblockCommand *commandFactory(RawRockblockCommand raw);
     uint32_t conseq_reads = 0;
     uint32_t same_mode = 0;

--- a/src/MissionMode.cpp
+++ b/src/MissionMode.cpp
@@ -433,7 +433,8 @@ void exit_detumble_phase(MissionMode *mode)
 void exit_insun_phase(MissionMode *mode)
 {
     if ((sfr::temperature::temp_c_average->is_valid() && sfr::temperature::in_sun) ||
-        (!sfr::temperature::temp_c_average->is_valid() && sfr::current::solar_current_average->is_valid() && sfr::current::in_sun)) {
+        (!sfr::temperature::temp_c_average->is_valid() && sfr::current::solar_current_average->is_valid() && sfr::current::in_sun) ||
+        (!sfr::temperature::temp_c_average->is_valid() && !sfr::current::solar_current_average->is_valid())) {
         sfr::mission::current_mode = mode;
     }
 }

--- a/src/MissionMode.cpp
+++ b/src/MissionMode.cpp
@@ -29,7 +29,7 @@ void AliveSignal::transition_to()
         sensor_power_mode_type::on,  // imu
         sensor_power_mode_type::off, // camera
         true,                        // acs off
-        0);
+        sfr::rockblock::transmit_downlink_period);
 }
 void AliveSignal::dispatch()
 {

--- a/src/Monitors/IMUDownlink.cpp
+++ b/src/Monitors/IMUDownlink.cpp
@@ -29,7 +29,7 @@ void IMUDownlink::execute()
             }
 
             // Delete older values if the dlink is larger then the maximum bytes downlinked
-            if (sfr::imu::imu_dlink.size() > constants::imu_downlink::max_imu_report_length) {
+            if (sfr::imu::imu_dlink.size() > constants::rockblock::max_imu_report_length) {
                 // If greater than the max size shrink the buffer
                 for (int i = 0; i < 3; i++) {
                     sfr::imu::imu_dlink.pop_back();

--- a/src/Monitors/IMUDownlink.cpp
+++ b/src/Monitors/IMUDownlink.cpp
@@ -23,9 +23,9 @@ void IMUDownlink::execute()
             // Checks if IMU Values are valid
             if (sfr::imu::gyro_x_value->get_value(&gyro_x) && sfr::imu::gyro_y_value->get_value(&gyro_y) && sfr::imu::gyro_z_value->get_value(&gyro_z)) {
                 // Add gyro values to the buffer as rad/s
-                sfr::imu::imu_dlink.push_front((gyro_x + 5) * 25);
-                sfr::imu::imu_dlink.push_front((gyro_y + 5) * 25);
-                sfr::imu::imu_dlink.push_front((gyro_z + 5) * 25);
+                sfr::imu::imu_dlink.push_front(NormalReportMonitor::serialize(sfr::imu::gyro_x_value));
+                sfr::imu::imu_dlink.push_front(NormalReportMonitor::serialize(sfr::imu::gyro_y_value));
+                sfr::imu::imu_dlink.push_front(NormalReportMonitor::serialize(sfr::imu::gyro_z_value));
             }
 
             // Delete older values if the dlink is larger then the maximum bytes downlinked

--- a/src/Monitors/IMUDownlink.hpp
+++ b/src/Monitors/IMUDownlink.hpp
@@ -2,6 +2,7 @@
 #define IMU_DOWNLINK_HPP_
 
 #include "Adafruit_LSM9DS1.h"
+#include "NormalReportMonitor.hpp"
 #include "sfr.hpp"
 #include <SD.h>
 

--- a/src/Monitors/IMUDownlinkReportMonitor.cpp
+++ b/src/Monitors/IMUDownlinkReportMonitor.cpp
@@ -52,8 +52,8 @@ void IMUDownlinkReportMonitor::create_imu_downlink_report(uint8_t fragment_numbe
         sfr::imu::imu_dlink.pop_back();
     }
     // Push end flag at the end of the report
-    sfr::rockblock::imu_report.push_back(constants::imu_downlink::imu_report_endflag1);
-    sfr::rockblock::imu_report.push_back(constants::imu_downlink::imu_report_endflag2);
+    sfr::rockblock::imu_report.push_back(constants::rockblock::imu_report_endflag1);
+    sfr::rockblock::imu_report.push_back(constants::rockblock::imu_report_endflag2);
 
     // For the next downlink cycle
     sfr::imu::report_ready = true;
@@ -105,8 +105,8 @@ void IMUDownlinkReportMonitor::create_imu_downlink_report_from_SD(uint8_t fragme
             sfr::rockblock::imu_report.push_back(parsedbuffer[i]);
         }
 
-        sfr::rockblock::imu_report.push_back(constants::imu_downlink::imu_report_endflag1);
-        sfr::rockblock::imu_report.push_back(constants::imu_downlink::imu_report_endflag2);
+        sfr::rockblock::imu_report.push_back(constants::rockblock::imu_report_endflag1);
+        sfr::rockblock::imu_report.push_back(constants::rockblock::imu_report_endflag2);
 
         sfr::imu::report_ready = true;
         sfr::imu::fragment_requested = false;

--- a/src/Monitors/NormalReportMonitor.cpp
+++ b/src/Monitors/NormalReportMonitor.cpp
@@ -14,7 +14,7 @@ void NormalReportMonitor::execute()
         sfr::mission::deployed, sfr::rockblock::waiting_command,
         sfr::temperature::in_sun, sfr::current::in_sun, sfr::button::pressed};
 
-    bool eeprom_bools[] = {0, 0, 0, 0, sfr::eeprom::boot_restarted, sfr::eeprom::error_mode, sfr::eeprom::light_switch, sfr::eeprom::sfr_save_completed};
+    bool eeprom_bools[] = {sfr::eeprom::boot_restarted, sfr::eeprom::error_mode, sfr::eeprom::light_switch, sfr::eeprom::sfr_save_completed, 0, 0, 0, 0};
 
     std::vector<uint8_t> report_contents{
         constants::rockblock::normal_report_flag,

--- a/src/Monitors/NormalReportMonitor.hpp
+++ b/src/Monitors/NormalReportMonitor.hpp
@@ -11,12 +11,12 @@ class NormalReportMonitor
 public:
     NormalReportMonitor();
     void execute();
+    static uint8_t serialize(SensorReading *valueObj);
+    static uint8_t serialize(float value, float min, float max);
 
 private:
-    uint8_t serialize(SensorReading *valueObj);
-    uint8_t serialize(int opcode);
-    uint8_t serialize(float value, float min, float max);
     uint8_t serialize(bool values[]);
+    uint8_t serialize(int opcode);
 };
 
 #endif

--- a/src/Monitors/RockblockReportMonitor.cpp
+++ b/src/Monitors/RockblockReportMonitor.cpp
@@ -48,7 +48,8 @@ void RockblockReportMonitor::switch_report_type_to(report_type downlink_report_t
 
 void RockblockReportMonitor::schedule_report()
 {
-    if (!sfr::rockblock::sleep_mode && millis() - sfr::rockblock::last_downlink >= sfr::rockblock::downlink_period) {
+    if (!sfr::rockblock::sleep_mode && (millis() - sfr::rockblock::last_downlink >= sfr::rockblock::downlink_period || !attempted_downlink)) {
+        attempted_downlink = true;
         // Check if in a low-power mode
         if (sfr::mission::current_mode->get_type() == mode_type::LP) {
             // In low-power mode; only enable normal report downlinks

--- a/src/Monitors/RockblockReportMonitor.hpp
+++ b/src/Monitors/RockblockReportMonitor.hpp
@@ -12,6 +12,7 @@ public:
 private:
     void switch_report_type_to(report_type downlink_report_type);
     void schedule_report();
+    bool attempted_downlink = false;
 };
 
 #endif

--- a/src/RockblockSimulator.cpp
+++ b/src/RockblockSimulator.cpp
@@ -14,9 +14,9 @@ RockblockSimulator::RockblockSimulator()
     signal = 5;
 
     // COMMANDS TO DEPLOY BURNWIRE
-    insert("FEFE33331111111111111111FAFA");
-    insert("FEFE44441111111111111111FAFA");
-    insert("FEFE55551111111111111111FAFA");
+    // insert("FEFE33331111111111111111FAFA");
+    // insert("FEFE44441111111111111111FAFA");
+    // insert("FEFE55551111111111111111FAFA");
 
     // Request camera fragment
     // insert("FEFE8888000000000000000000FA");

--- a/src/RockblockSimulator.cpp
+++ b/src/RockblockSimulator.cpp
@@ -14,9 +14,9 @@ RockblockSimulator::RockblockSimulator()
     signal = 5;
 
     // COMMANDS TO DEPLOY BURNWIRE
-    insert("FEFE3333111111111111111100FA");
-    insert("FEFE4444111111111111111100FA");
-    insert("FEFE5555111111111111111100FA");
+    insert("FEFE33331111111111111111FAFA");
+    insert("FEFE44441111111111111111FAFA");
+    insert("FEFE55551111111111111111FAFA");
 
     // Request camera fragment
     // insert("FEFE8888000000000000000000FA");

--- a/src/RockblockSimulator.cpp
+++ b/src/RockblockSimulator.cpp
@@ -12,24 +12,17 @@ RockblockSimulator::RockblockSimulator()
     flush_stage = 0;
     bin_transmit = 0;
     signal = 5;
-    // Command with end of command flag
-    // opcode 1901
-    // arg_1  11111111
-    // arg_2  00000000
-    // end of command upload flag 1 00
-    // end of command upload flag 2 FA
-    // insert("1901111111110000000000FA");
 
     // COMMANDS TO DEPLOY BURNWIRE
-    // insert("3333111111111111111100FA");
-    // insert("4444111111111111111100FA");
-    // insert("5555111111111111111100FA");
+    insert("FEFE3333111111111111111100FA");
+    insert("FEFE4444111111111111111100FA");
+    insert("FEFE5555111111111111111100FA");
 
     // Request camera fragment
-    // insert("8888000000000000000000FA");
+    // insert("FEFE8888000000000000000000FA");
 
     // Request IMU fragment
-    // insert("9999000000000000000000FA");
+    // insert("FEFE9999000000000000000000FA");
 }
 
 void RockblockSimulator::begin(uint32_t baud)

--- a/src/SensorReading.cpp
+++ b/src/SensorReading.cpp
@@ -37,6 +37,10 @@ void SensorReading::set_value(float x)
         set_invalid();
     }
 
+    if (buffer.size() != buffer_size) {
+        set_invalid();
+    }
+
 } // mutator for buffer
 
 void SensorReading::set_valid()

--- a/src/SensorReading.cpp
+++ b/src/SensorReading.cpp
@@ -16,9 +16,9 @@ bool SensorReading::get_value(float *value_location)
         // get average value
         float average = (std::accumulate(buffer.begin(), buffer.end(), 0.0)) / buffer_size;
         *value_location = average;
-        return 1;
+        return true;
     } else {
-        return 0;
+        return false;
     }
 }
 

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -48,6 +48,10 @@ namespace constants {
         constexpr size_t command_len = opcode_len + arg1_len + arg2_len;
         constexpr size_t max_conseq_read = 3;
 
+        constexpr int max_imu_report_length = 1188;
+        constexpr uint8_t imu_report_endflag1 = 0xFE;
+        constexpr uint8_t imu_report_endflag2 = 0x92;
+
         constexpr uint8_t normal_report_flag = 99;
         constexpr uint8_t imu_report_flag = 24;
         constexpr uint8_t camera_report_flag = 42;
@@ -265,12 +269,6 @@ namespace constants {
         constexpr int sfr_resolution = 10;
     } // namespace imu
 
-    namespace imu_downlink {
-        // Note this is how much data correlates to 30 seconds
-        constexpr int max_imu_report_length = 1188;
-        constexpr uint8_t imu_report_endflag1 = 0xFE;
-        constexpr uint8_t imu_report_endflag2 = 0x92;
-    } // namespace imu_downlink
     namespace eeprom {
         // Byte locations of the EEPROM blue moon data
         static constexpr unsigned int boot_time_loc1 = 0;


### PR DESCRIPTION
# Detailed prints for downlinks

### Summary of changes
- Detailed prints for downlinks when using VERBOSE flag
- eeprom_bools fix 
- Remove extra verbose flags
- Use map function for IMU downlink