### PR TITLE
Revised extra _script.py location in platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,7 +17,7 @@ test_build_src = true
 board_build.f_cpu = 24000000L
 build_flags = -D VERBOSE -D TEENSY_OPT_SMALLEST_CODE
 lib_ldf_mode = deep
-extra_scripts = pre:src/extra_script.py
+extra_scripts = pre:tools/extra_script.py
 test_port = /dev/ttyACM0
 
 [env:teensy35]


### PR DESCRIPTION
Gets rid of the SConscript missing script warning.