### PR TITLE
 Remove ACS Pointing Mode

### DIFF
--- a/src/Control Tasks/ACSControlTask.cpp
+++ b/src/Control Tasks/ACSControlTask.cpp
@@ -77,12 +77,6 @@ void ACSControlTask::execute()
                 sfr::acs::current_x = starshotObj.rtY.detumble[0];
                 sfr::acs::current_y = starshotObj.rtY.detumble[1];
                 sfr::acs::current_z = starshotObj.rtY.detumble[2];
-
-            } else if (sfr::acs::mode == (uint8_t)acs_mode_type::point) {
-                sfr::acs::current_x = starshotObj.rtY.point[0];
-                sfr::acs::current_y = starshotObj.rtY.point[1];
-
-                sfr::acs::current_z = starshotObj.rtY.point[2];
             } else if (sfr::acs::mode == (uint8_t)acs_mode_type::simple) {
                 sfr::acs::current_x = 0;
                 sfr::acs::current_y = 0;
@@ -122,8 +116,6 @@ void ACSControlTask::execute()
     if (sfr::acs::mode == 0) {
         Serial.print("SIMPLE, ");
     } else if (sfr::acs::mode == 1) {
-        Serial.print("POINT, ");
-    } else if (sfr::acs::mode == 2) {
         Serial.print("DETUMBLE, ");
     }
 

--- a/src/MainControlLoop.cpp
+++ b/src/MainControlLoop.cpp
@@ -65,9 +65,6 @@ void MainControlLoop::execute()
     case ((uint8_t)acs_mode_type::simple):
         Serial.println("SIMPLE");
         break;
-    case ((uint8_t)acs_mode_type::point):
-        Serial.println("POINT");
-        break;
     case ((uint8_t)acs_mode_type::detumble):
         Serial.println("DETUMBLE");
         break;

--- a/src/MissionMode.cpp
+++ b/src/MissionMode.cpp
@@ -488,7 +488,7 @@ void exit_detumble_phase(MissionMode *mode)
     // invalid readings from IMU
     if (sfr::imu::failed_times >= sfr::imu::failed_limit) {
         sfr::mission::current_mode = mode;
-        sfr::acs::mode = (uint8_t)acs_mode_type::point;
+        sfr::acs::mode = (uint8_t)acs_mode_type::simple;
     }
 
     // cubesat stabilized
@@ -496,20 +496,20 @@ void exit_detumble_phase(MissionMode *mode)
         sfr::imu::gyro_x_average->get_value(&gyro_x) && gyro_x <= sfr::detumble::max_stable_gyro_x.get_float() &&
         sfr::imu::gyro_y_average->get_value(&gyro_y) && gyro_y <= sfr::detumble::max_stable_gyro_y.get_float()) {
         sfr::mission::current_mode = mode;
-        sfr::acs::mode = (uint8_t)acs_mode_type::point;
+        sfr::acs::mode = (uint8_t)acs_mode_type::simple;
     }
 
     // cubesat will never stabilize
     if ((sfr::imu::gyro_x_average->get_value(&gyro_x) && gyro_x >= sfr::detumble::min_unstable_gyro_x.get_float()) ||
         (sfr::imu::gyro_y_average->get_value(&gyro_y) && gyro_y >= sfr::detumble::min_unstable_gyro_y.get_float())) {
         sfr::mission::current_mode = mode;
-        sfr::acs::mode = (uint8_t)acs_mode_type::point;
+        sfr::acs::mode = (uint8_t)acs_mode_type::simple;
     }
 
     // detumble has timed out
     if (millis() - sfr::mission::stabilization->start_time >= sfr::stabilization::max_time) {
         sfr::mission::current_mode = mode;
-        sfr::acs::mode = (uint8_t)acs_mode_type::point;
+        sfr::acs::mode = (uint8_t)acs_mode_type::simple;
     }
 }
 
@@ -577,7 +577,7 @@ void exit_alive_signal()
     if (sfr::eeprom::time_alive >= (sfr::boot::max_time + sfr::stabilization::max_time)) {
         sfr::mission::current_mode = sfr::mission::transmit;
         if (sfr::acs::mode == (uint8_t)acs_mode_type::detumble) {
-            sfr::acs::mode = (uint8_t)acs_mode_type::point;
+            sfr::acs::mode = (uint8_t)acs_mode_type::simple;
         }
     } else {
         sfr::mission::current_mode = sfr::mission::detumbleSpin;

--- a/src/Modes/acs_mode_type.enum
+++ b/src/Modes/acs_mode_type.enum
@@ -4,7 +4,6 @@
 enum class acs_mode_type : unsigned char
 {
     simple = 0,
-    point,
     detumble
 };
 


### PR DESCRIPTION
# Remove ACS Pointing Mode


### Summary of changes
- By default, when not in detumble ACS shall be in pointing
- Normal mode remains the same (now, no additional ACS related power will be consumed in Normal mode unless simple_current is modified via uplink)

