### PR TITLE
Max Signal Check

### DIFF
--- a/src/Control Tasks/RockblockControlTask.cpp
+++ b/src/Control Tasks/RockblockControlTask.cpp
@@ -139,6 +139,7 @@ void RockblockControlTask::dispatch_standby()
     } else {
         Pins::setPinState(constants::rockblock::sleep_pin, LOW);
     }
+    signal_checks = 0;
 }
 
 void RockblockControlTask::dispatch_send_at()
@@ -917,8 +918,14 @@ void RockblockControlTask::get_valid_signal(rockblock_mode_type good_signal, roc
 #endif
         if (signal == '3' || signal == '4' || signal == '5') {
             transition_to(good_signal);
+            signal_checks++;
         } else {
             transition_to(bad_signal);
+        }
+
+        if (signal_checks >= sfr::rockblock::max_signal_check) {
+            Serial.println("SAT INFO: signal checks failed max times");
+            transition_to(rockblock_mode_type::end_transmission);
         }
     }
 }

--- a/src/Control Tasks/RockblockControlTask.hpp
+++ b/src/Control Tasks/RockblockControlTask.hpp
@@ -51,6 +51,7 @@ private:
     uint32_t same_mode = 0;
     uint8_t look_ahead1 = -1;
     uint8_t look_ahead2 = -1;
+    uint8_t signal_checks = 0;
 };
 
 #endif

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -289,7 +289,7 @@ namespace constants {
         static constexpr unsigned int dynamic_data_start = 10;
         static constexpr unsigned int sfr_data_start = 460;
         static constexpr unsigned int sfr_store_size = 5;
-        static constexpr unsigned int sfr_num_fields = 90;
+        static constexpr unsigned int sfr_num_fields = 91;
         static constexpr unsigned int sfr_data_full_offset = sfr_num_fields * sfr_store_size + 4;
         static constexpr unsigned int write_age_limit = 95000; // Must be less than 100000
 

--- a/src/sfr.cpp
+++ b/src/sfr.cpp
@@ -147,13 +147,14 @@ namespace sfr {
         SFRField<bool> sleep_mode = SFRField<bool>(false, 0x2102);
         SFRField<uint8_t> max_commands_count = SFRField<uint8_t>(6, 0x2103);
         SFRField<uint8_t> queue_limit = SFRField<uint8_t>(5, 0x2104);
-        SFRField<uint16_t> downlink_report_type = SFRField<uint16_t>((uint16_t)report_type::normal_report, 0x2105);
-        SFRField<uint16_t> mode = SFRField<uint16_t>((uint16_t)rockblock_mode_type::standby, 0x2106);
-        SFRField<uint32_t> last_downlink = SFRField<uint32_t>(0, 0x2107);
-        SFRField<uint32_t> downlink_period = SFRField<uint32_t>(20 * constants::time::one_minute, 0, 2 * constants::time::one_day, 0x2108);
-        SFRField<uint32_t> lp_downlink_period = SFRField<uint32_t>(constants::time::one_hour, constants::time::one_second, 2 * constants::time::one_day, 0x2109);
-        SFRField<uint32_t> transmit_downlink_period = SFRField<uint32_t>(20 * constants::time::one_minute, constants::time::one_second, 2 * constants::time::one_day, 0x2110);
-        SFRField<uint32_t> on_time = SFRField<uint32_t>(35 * constants::time::one_minute, 0, constants::time::one_revolution, 0x2111);
+        SFRField<uint8_t> max_signal_check = SFRField<uint8_t>(3, 0x2105);
+        SFRField<uint16_t> downlink_report_type = SFRField<uint16_t>((uint16_t)report_type::normal_report, 0x2106);
+        SFRField<uint16_t> mode = SFRField<uint16_t>((uint16_t)rockblock_mode_type::standby, 0x2107);
+        SFRField<uint32_t> last_downlink = SFRField<uint32_t>(0, 0x2108);
+        SFRField<uint32_t> downlink_period = SFRField<uint32_t>(20 * constants::time::one_minute, 0, 2 * constants::time::one_day, 0x2109);
+        SFRField<uint32_t> lp_downlink_period = SFRField<uint32_t>(constants::time::one_hour, constants::time::one_second, 2 * constants::time::one_day, 0x2110);
+        SFRField<uint32_t> transmit_downlink_period = SFRField<uint32_t>(20 * constants::time::one_minute, constants::time::one_second, 2 * constants::time::one_day, 0x2111);
+        SFRField<uint32_t> on_time = SFRField<uint32_t>(35 * constants::time::one_minute, 0, constants::time::one_revolution, 0x2112);
 
         char buffer[constants::rockblock::buffer_size] = {0};
         uint8_t commas[constants::rockblock::num_commas] = {0};

--- a/src/sfr.hpp
+++ b/src/sfr.hpp
@@ -167,6 +167,7 @@ namespace sfr {
         extern SFRField<bool> sleep_mode;
         extern SFRField<uint8_t> max_commands_count;
         extern SFRField<uint8_t> queue_limit;
+        extern SFRField<uint8_t> max_signal_check;
         extern SFRField<uint16_t> downlink_report_type;
         extern SFRField<uint16_t> mode;
         extern SFRField<uint32_t> last_downlink;


### PR DESCRIPTION
# Only allow 3 "good" max signal checks per downlink attempt

### Summary of changes
- Do not allow more than 3 potential hard faults (rockblock thinks signal is good, but downlink fails) per downlink attempt