### PR TITLE
IMU disable fault

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -12,13 +12,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Cache pip
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
         restore-keys: ${{ runner.os }}-pip-
     - name: Cache PlatformIO
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.platformio
         key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}

--- a/src/Faults.cpp
+++ b/src/Faults.cpp
@@ -14,6 +14,7 @@ namespace fault_groups {
         Fault *gyro_y_average = new Fault(0x6009);
         Fault *gyro_z_value = new Fault(0x6010);
         Fault *gyro_z_average = new Fault(0x6011);
+        Fault *imu_disable = new Fault(0x6012);
     } // namespace imu_faults
     namespace power_faults {
         Fault *temp_c_value = new Fault(0x6020);

--- a/src/Faults.hpp
+++ b/src/Faults.hpp
@@ -17,6 +17,7 @@ namespace fault_groups {
         extern Fault *gyro_y_average;
         extern Fault *gyro_z_value;
         extern Fault *gyro_z_average;
+        extern Fault *imu_disable;
     } // namespace imu_faults
     namespace power_faults {
         extern Fault *temp_c_value;

--- a/src/Monitors/IMUMonitor.cpp
+++ b/src/Monitors/IMUMonitor.cpp
@@ -36,7 +36,7 @@ void IMUMonitor::execute()
         sfr::imu::power_setting = (uint8_t)sensor_power_mode_type::do_nothing;
     }
 
-    if (sfr::imu::power_setting == (uint8_t)sensor_power_mode_type::on && sfr::imu::powered == false) {
+    if (sfr::imu::power_setting == (uint8_t)sensor_power_mode_type::on && sfr::imu::powered == false && !fault_groups::imu_faults::imu_disable->get_base()) {
 #ifdef VERBOSE
         Serial.println("Turned on IMU");
 #endif


### PR DESCRIPTION
# Addition of imu_disable fault

### Summary of changes
- Addition of `imu_disable` imu_fault (opcode 0x6012), which must not be signaled in order to enable IMU initialization. This allows the IMU to be indefinitely powered off to reduce current consumption with only 2 Rockblock commands (without having to enter low-power mode) 
- To minimize risk to the flight software and reduce the need for additional testing, this new fault is as silent as possible. It can not be triggered via any means except Rockblock command, and the normal report has not been modified to include it. The processed commands section of the normal report and gyro/mag fault fields will provide secondary verification of fault signaling. 
- Due to cache v2 being depreciated as of March 1st, the worflows.yml file has been updated to prevent the build failing


### Testing

- Functionality of toggling IMU power state, both in low power mode and via IMU disable fault, validated via flatsats 1 and 2 with GS in the loop. 
- December 2024 testing consisted of sending two commands to the flatsat via GS during the Transmit phase of a nominal test: one to raise the low power threshold and one to set the `imu_power_setting` to off. Positive effect on power budget verified via power budget logging scripts. IMU toggled back on via Rockblock command, with proper sensor functionality verified after restart. Nominal test completed successfully.
- March 2025 testing consisted of sending two Rockblock commands to the flatsat via GS during the Transmit phase of a nominal test: forcing the `imu_disable` fault and setting the `imu_power_setting` to off. Positive effect on power budget (35 mA in transmit, IMU on / 27 mA in transmit, IMU off / 22 mA in normal, IMU off) verified via power supply display. Command processing verified via normal report and serial log. IMU toggled back on via Rockblock command to suppress `imu_disable` fault, with proper sensor functionality verified after restart. During IMU shutdown, verified that current output to all magnetorquers was zero. All associated faults triggered by IMU shutdown verified reset after IMU restart. Nominal test completed successfully.

### SFR Changes
None