### PR TITLE
add second ODS capture + delayed first capture

### DIFF
--- a/src/Control Tasks/CameraControlTask.cpp
+++ b/src/Control Tasks/CameraControlTask.cpp
@@ -155,8 +155,8 @@ void CameraControlTask::execute()
 
     // handle taking and storing photos
     if (sfr::camera::take_photo == true && sfr::camera::powered == true) {
-        // extra 200ms delay between commanding photo and triggering capture
-        if (sfr::camera::start_progress < 8) {
+        // extra delay (200 ms default) between commanding photo and triggering capture
+        if (sfr::camera::start_progress < (sfr::camera::delay_count + 6)) {
             sfr::camera::start_progress++;
 #ifdef VERBOSE
             Serial.println("Photo triggered, delaying additional 100ms");

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -293,7 +293,7 @@ namespace constants {
         static constexpr unsigned int dynamic_data_start = 10;
         static constexpr unsigned int sfr_data_start = 460;
         static constexpr unsigned int sfr_store_size = 5;
-        static constexpr unsigned int sfr_num_fields = 92;
+        static constexpr unsigned int sfr_num_fields = 93;
         static constexpr unsigned int sfr_data_full_offset = sfr_num_fields * sfr_store_size + 4;
         static constexpr unsigned int write_age_limit = 95000; // Must be less than 100000
 

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -86,7 +86,7 @@ namespace constants {
             constexpr uint16_t fault_opcode_max = 0x6100;
 
         } // namespace opcodes
-    }     // namespace rockblock
+    } // namespace rockblock
     namespace temperature {
         constexpr int pin = 39;
         constexpr int in_sun_val = 30;
@@ -98,7 +98,7 @@ namespace constants {
         constexpr float in_sun_val = 70; // mA
         constexpr int load = 30;         // load resister value (kOhm)
         constexpr float shunt = 0.1;     // shunt resistor value (Ohm)
-    }                                    // namespace current
+    } // namespace current
     namespace masks {
         constexpr uint32_t uint32_byte1_mask = 0b11111111000000000000000000000000;
         constexpr uint32_t uint32_byte2_mask = 0b00000000111111110000000000000000;
@@ -248,7 +248,7 @@ namespace constants {
     } // namespace battery
     namespace camera {
         constexpr int power_on_pin = 31;
-        constexpr int content_length = 64;
+        constexpr int content_length = 80;
         constexpr int bytes_allocated_fragment = 4;
         constexpr int tx = 34;
         constexpr int rx = 33;
@@ -304,6 +304,6 @@ namespace constants {
     namespace watchdog {
         constexpr uint32_t max_period_ms = 10000;
     } // namespace watchdog
-};    // namespace constants
+}; // namespace constants
 
 #endif

--- a/src/sfr.cpp
+++ b/src/sfr.cpp
@@ -17,7 +17,7 @@ namespace sfr {
         SFRField<uint8_t> max_stable_gyro_y = SFRField<uint8_t>((0.2 * constants::imu::sfr_resolution), 0x1502, constants::imu::sfr_resolution);   // rad/s
         SFRField<uint8_t> min_unstable_gyro_x = SFRField<uint8_t>((0.7 * constants::imu::sfr_resolution), 0x1503, constants::imu::sfr_resolution); // rad/s
         SFRField<uint8_t> min_unstable_gyro_y = SFRField<uint8_t>((0.7 * constants::imu::sfr_resolution), 0x1504, constants::imu::sfr_resolution); // rad/s
-    }                                                                                                                                              // namespace detumble
+    } // namespace detumble
     namespace aliveSignal {
         // OP Codes 1600
         SFRField<bool> downlinked = SFRField<bool>(false, 0x1600);
@@ -139,6 +139,7 @@ namespace sfr {
         SFRField<uint32_t> fragment_number_requested = SFRField<uint32_t>(0, 0x2016);
         SFRField<uint32_t> power_start_time = SFRField<uint32_t>(0, 0x2017);
         SFRField<uint32_t> power_time = SFRField<uint32_t>(400, 0x2018);
+        SFRField<uint8_t> delay_count = SFRField<uint8_t>(2, 0x2019);
     } // namespace camera
     namespace rockblock {
         // OP Codes 2100
@@ -283,4 +284,4 @@ namespace sfr {
         SFRField<uint32_t> dynamic_data_age = SFRField<uint32_t>(0, 0x2809);
         SFRField<uint32_t> sfr_data_age = SFRField<uint32_t>(0, 0x2810);
     } // namespace eeprom
-};    // namespace sfr
+}; // namespace sfr

--- a/src/sfr.hpp
+++ b/src/sfr.hpp
@@ -159,6 +159,7 @@ namespace sfr {
         extern SFRField<uint32_t> fragment_number_requested;
         extern SFRField<uint32_t> power_start_time;
         extern SFRField<uint32_t> power_time;
+        extern SFRField<uint8_t> delay_count;
     } // namespace camera
     namespace rockblock {
         // OP Codes 2100
@@ -286,6 +287,6 @@ namespace sfr {
         extern SFRField<uint32_t> dynamic_data_age;
         extern SFRField<uint32_t> sfr_data_age;
     } // namespace eeprom
-};    // namespace sfr
+}; // namespace sfr
 
 #endif


### PR DESCRIPTION
# ODS Capture Changes


### Summary of changes
Motivation of this PR is to increase the likelihood of a successful capture of the lightsail after deployment via the ODS. This involves tweaking the timing of the first photo, as well as taking a supplemental backup photo shortly after the first, in the event that the timing/spin of the CubeSat does not produce a good first image. 

- `CameraControlTask.cpp` modified to automatically trigger a second photo capture during deployment, ~4.6 seconds after the first. This capture occurs after the first photo is written to the SD card, and involves resuming and recapturing the camera frame before ultimately powering off the camera and SD. 
- Initial photo capture sequence modified to pause for two control cycles (200 ms) after open door toggles `sfr::camera::take_photo` before capturing photo. This is accomplished by continuing to increment the `sfr::camera::start_progress` field (used to monitor camera initialization progress) from 6 to 8 before calling `adaCam.takePicture()`. Consider renaming sfr field if this variable reuse justifies changes to sfr references and GS, but would like to avoid this, since the SFR field is still being used for its original purpose of incrementally triggering camera operations. This change was precipitated by testing on the flight unit in February 2025 that revealed Spring 2022 testing (which had indicated no additional delay was necessary between button depress and photo capture for exposure or framing purposes) did not match results on the flight unit. Potentially due to hardware differences in button responsiveness, camera exposure adjustment speed, or speed of light sail deployment with the flight sail vs dummy. 
- Additionally, `sfr::camera::start_progress` reset to 0 after ODS shutdown. In current flight software, if operators attempted to command a supplemental camera capture at some point after deployment, camera initialization would not be successful without the progress counter being reset. 
- Length of the camera report changed from 70 bytes (64 bytes photo data) to 86 bytes (80 bytes photo data) in order to reduce total number of camera fragments for 2 photos below 100. Testing revealed that reading more than 100 consecutive camera fragments from VC-0706 unit resulted in corrupted fragments, due to presumed hardware limitations. 


### Testing
- Extensive flatsat testing in F24 semester confirmed the functionality of double photo capture change, including GS decoding and no significant negative power budget results involved with transmitting two photos. See [FA24 semester report](https://cornell.box.com/s/qyhpil1gyt7yrk5i9xjfrdt3ah4iovtj) for documentation. This testing revealed that `resumeVideo()` must be called before calling `takePicture()` again in order to avoid rereading the same image data as a "second photo" when writing to the SD card. 
- Subsequent testing in January 2025 indicated that issues downlinking corrupted/incomplete second images were due to a bug when attempting to read more than 100 consecutive camera fragments from the camera module. Indirect references to this limitation were found in online documentation for the VC-0706 module, although the exact causation was not determined. As a workaround, the size of each camera report was increased by ~20% in order to reduce the total number of camera fragments written, after discussions with Josh indicated that the 70-byte report size specified in flight software was entirely arbitrary (although smaller values result in a shorter transmission time which increases the likelihood of successful transmission), and could (from a Rockblock perspective) be doubled or tripled if necessary.
- Testing in February and March 2025 confirmed that this change to ODS report size has no negative impacts on power budget, requires no changes to the ground station for decoding, and requires no changes to the flight software besides modification of the `constants::camera::content_length` value. Validation of both the report size change and addition of a second photo was accomplished with the following configurations: flatsat with Rockblock simulator, flatsat with ground Rockblock/ground station in the loop, EDU with rockblock simulator, flight unit with rockblock simulator. This testing occurred largely after nominal testing on the flight unit with GS in the loop, as the acceptance-tested CubeSat can no longer be used for deployment tests. Formal test summaries haven't been compiled yet due to timeline constraints, but can be produced if concerns exist about any of this testing. 

### SFR Changes
- No sfr changes, but `constants::camera::content_length` changed from 64 to 80 to increase the size of the camera report by 16 bytes
- (Edit 3/11): delay counter changed from hardcoded value [8 = 6(prexisting value) +2 (control cycles)] to reference a `camera::delay_count` SFR field, to enable flexibility in sail deployment timing should additional testing reveal an alternate value should be used 